### PR TITLE
refactor: move config management to ExtensionContainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,7 +282,6 @@
           "type": "string",
           "default": "info",
           "description": "Logging level for commands being run",
-          "scope": "window",
           "enum": [
             "debug",
             "error",

--- a/package.json
+++ b/package.json
@@ -454,12 +454,12 @@
       "view/title": [
         {
           "command": "titanium.build.setLiveViewEnabled",
-          "when": "view == titaniumExplorer && config.titanium.liveview && !titanium:liveview",
+          "when": "view == titaniumExplorer && !config.titanium.build.liveview",
           "group": "navigation"
         },
         {
           "command": "titanium.build.setLiveViewDisabled",
-          "when": "view == titaniumExplorer && config.titanium.liveview && titanium:liveview",
+          "when": "view == titaniumExplorer && config.titanium.build.liveview",
           "group": "navigation"
         },
         {

--- a/package.json
+++ b/package.json
@@ -232,29 +232,26 @@
       "type": "object",
       "title": "Appcelerator Titanium",
       "properties": {
-        "titanium.general.appcCommandPath": {
+        "titanium.android.keystoreAlias": {
           "type": "string",
-          "default": "appc",
-          "description": "Set the full path to the `appc` command if VS Code is unable to locate it. Run init command."
+          "default": "",
+          "description": "Keystore alias"
         },
-        "titanium.general.displayBuildCommandInConsole": {
+        "titanium.android.keystorePath": {
+          "type": "string",
+          "default": "",
+          "description": "Keystore path"
+        },
+        "titanium.build.liveview": {
           "type": "boolean",
           "default": true,
-          "description": "The executed build command is written to the console to aid debugging. This will include password arguments."
+          "description": "Whether to use LiveView when building",
+          "scope": "window"
         },
-        "titanium.general.useTerminalForBuild": {
-          "type": "boolean",
-          "default": true,
-          "description": "Build command will be run using the integrated terminal."
-        },
-        "titanium.project.defaultI18nLanguage": {
+        "titanium.codeTemplates.jsFunction": {
           "type": "string",
-          "default": "en"
-        },
-        "titanium.package.distributionOutputDirectory": {
-          "type": "string",
-          "default": "dist",
-          "description": "For iOS ad-hoc and App Store and Google Play builds. Ensure this location has write permission."
+          "default": "\\nfunction ${text}(e){\\n}\\n",
+          "description": "Event handler function template"
         },
         "titanium.codeTemplates.tssClass": {
           "type": "string",
@@ -271,31 +268,47 @@
           "default": "\\n'${text}': {\\n}\\n",
           "description": "Style tag template"
         },
-        "titanium.codeTemplates.jsFunction": {
+        "titanium.general.appcCommandPath": {
           "type": "string",
-          "default": "\\nfunction ${text}(e){\\n}\\n",
-          "description": "Event handler function template"
+          "default": "appc",
+          "description": "Set the full path to the `appc` command if VS Code is unable to locate it. Run init command."
         },
-        "titanium.iOS.showProvisioningProfileDetail": {
+        "titanium.general.displayBuildCommandInConsole": {
+          "type": "boolean",
+          "default": true,
+          "description": "The executed build command is written to the console to aid debugging. This will include password arguments."
+        },
+        "titanium.general.logLevel": {
+          "type": "string",
+          "default": "info",
+          "description": "Logging level for commands being run",
+          "scope": "window",
+          "enum": [
+            "debug",
+            "error",
+            "info",
+            "trace",
+            "warn"
+          ]
+        },
+        "titanium.general.useTerminalForBuild": {
+          "type": "boolean",
+          "default": true,
+          "description": "Build command will be run using the integrated terminal."
+        },
+        "titanium.ios.showProvisioningProfileDetail": {
           "type": "boolean",
           "default": false,
           "description": "Show provisioning profile app ID and expiry information in picker"
         },
-        "titanium.android.keystorePath": {
+        "titanium.package.distributionOutputDirectory": {
           "type": "string",
-          "default": "",
-          "description": "Keystore path"
+          "default": "dist",
+          "description": "For iOS ad-hoc and App Store and Google Play builds. Ensure this location has write permission."
         },
-        "titanium.android.keystoreAlias": {
+        "titanium.project.defaultI18nLanguage": {
           "type": "string",
-          "default": "",
-          "description": "Keystore alias"
-        },
-        "titanium.liveview": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether to use LiveView when building",
-          "scope": "window"
+          "default": "en"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -295,11 +295,6 @@
           "default": true,
           "description": "Build command will be run using the integrated terminal."
         },
-        "titanium.ios.showProvisioningProfileDetail": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show provisioning profile app ID and expiry information in picker"
-        },
         "titanium.package.distributionOutputDirectory": {
           "type": "string",
           "default": "dist",

--- a/src/appc.ts
+++ b/src/appc.ts
@@ -1,13 +1,13 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as semver from 'semver';
-import { iOSProvisioinngProfileMatchesAppId } from './utils';
 
 import { spawn } from 'child_process';
 import { homedir } from 'os';
-import { window, workspace } from 'vscode';
-
+import { window } from 'vscode';
+import { ExtensionContainer } from './container';
 import { IosCert } from './types/common';
+import { iOSProvisioinngProfileMatchesAppId } from './utils';
 
 export interface AlloyGenerateOptions {
 	adapterType?: string;
@@ -352,8 +352,8 @@ export class Appc {
 			return;
 		}
 		const channel = window.createOutputChannel('Appcelerator');
-		const cmd: string = workspace.getConfiguration('titanium.general').get('appcCommandPath');
-		if (workspace.getConfiguration('titanium.general').get('displayBuildCommandInConsole')) {
+		const cmd = ExtensionContainer.config.general.appcCommandPath;
+		if (ExtensionContainer.config.general.displayBuildCommandInConsole) {
 			channel.append(`${cmd} run ${opts.args.join(' ')}\n\n`);
 		}
 		this.killed = false;

--- a/src/commands/buildApp.ts
+++ b/src/commands/buildApp.ts
@@ -23,9 +23,9 @@ export async function buildApplication (node: DeviceNode | OSVerNode | PlatformN
 		checkLogin();
 		// TODO: Handle a build in progress
 		const buildType = 'run';
-		const liveview = ExtensionContainer.context.globalState.get<boolean>(GlobalState.Liveview);
+		const liveview = ExtensionContainer.config.build.liveview;
 		const lastBuildState = ExtensionContainer.context.workspaceState.get<any>(WorkspaceState.LastBuildState);
-
+		const logLevel = ExtensionContainer.config.general.logLevel;
 		let deviceId;
 		let deviceLabel;
 		let iOSCertificate;
@@ -118,6 +118,7 @@ export async function buildApplication (node: DeviceNode | OSVerNode | PlatformN
 			target,
 			iOSCertificate,
 			iOSProvisioningProfile,
+			logLevel
 		};
 		const args = buildArguments(buildInfo, 'app');
 		ExtensionContainer.context.workspaceState.update(WorkspaceState.LastBuildState, buildInfo);

--- a/src/commands/buildModule.ts
+++ b/src/commands/buildModule.ts
@@ -13,7 +13,7 @@ export async function buildModule (node: DeviceNode | OSVerNode | PlatformNode |
 		checkLogin();
 		// TODO: Handle a build in progress, allow passing in emulators etc. here? And actually use package for dist modules?
 		const buildType = 'run';
-
+		const logLevel = ExtensionContainer.config.general.logLevel;
 		let platform;
 
 		if (node) {
@@ -27,7 +27,8 @@ export async function buildModule (node: DeviceNode | OSVerNode | PlatformNode |
 
 		const buildInfo = {
 			buildType,
-			platform
+			platform,
+			logLevel
 		};
 		const args = buildArguments(buildInfo, 'module');
 		ExtensionContainer.context.workspaceState.update(WorkspaceState.LastBuildState, buildInfo);

--- a/src/commands/packageApp.ts
+++ b/src/commands/packageApp.ts
@@ -16,6 +16,7 @@ export async function packageApplication (node: DeviceNode | OSVerNode | Platfor
 		// TODO: Handle a build in progress
 		const buildType = 'dist';
 		const lastBuildState = ExtensionContainer.context.workspaceState.get<any>(WorkspaceState.LastPackageState);
+		const logLevel = ExtensionContainer.config.general.logLevel;
 
 		let iOSCertificate;
 		let lastBuildDescription;
@@ -75,7 +76,7 @@ export async function packageApplication (node: DeviceNode | OSVerNode | Platfor
 		}
 
 		if (!outputDirectory) {
-			const distDirectory = workspace.getConfiguration('titanium.package').get<string>('distributionOutputDirectory');
+			const distDirectory = ExtensionContainer.config.package.distributionOutputDirectory;
 			if (!path.isAbsolute(distDirectory)) {
 				outputDirectory = path.join(workspace.rootPath, distDirectory);
 			} else {
@@ -90,7 +91,8 @@ export async function packageApplication (node: DeviceNode | OSVerNode | Platfor
 			keystoreInfo,
 			target,
 			iOSCertificate,
-			iOSProvisioningProfile
+			iOSProvisioningProfile,
+			logLevel
 		};
 		const storableInfo = Object.assign({}, buildInfo, { keystoreInfo: { password: null }});
 		ExtensionContainer.context.workspaceState.update(WorkspaceState.LastPackageState, storableInfo);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,34 @@
+import { ConfigurationChangeEvent, ConfigurationTarget, ExtensionContext, Uri, workspace } from 'vscode';
+import { ExtensionId } from './constants';
+import { ExtensionContainer } from './container';
+
+export class Configuration {
+	public static configure (context: ExtensionContext) {
+		context.subscriptions.push(
+			workspace.onDidChangeConfiguration(configuration.onConfigurationChanged, configuration)
+		);
+	}
+
+	public get<T> (section?: string, resource?: Uri, defaultValue?: T) {
+		return defaultValue === undefined
+			? workspace
+					.getConfiguration(section === undefined ? undefined : ExtensionId, resource!)
+					.get<T>(section === undefined ? ExtensionId : section)!
+			: workspace
+					.getConfiguration(section === undefined ? undefined : ExtensionId, resource!)
+					.get<T>(section === undefined ? ExtensionId : section, defaultValue)!;
+	}
+
+	public update (section: string, value: any, target: ConfigurationTarget, resourece?: Uri) {
+		return workspace
+			.getConfiguration(ExtensionId, target === ConfigurationTarget.Global ? undefined : resourece!)
+			.update(section, value, target);
+	}
+
+	private onConfigurationChanged (e: ConfigurationChangeEvent) {
+		ExtensionContainer.resetConfig();
+	}
+}
+
+export const configuration = new Configuration();
+export * from './types/config';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+export const ExtensionId = 'titanium';
+
 export enum VSCodeCommands {
 	OpenFolder = 'vscode.openFolder',
 	SetContext = 'setContext'
@@ -15,6 +17,5 @@ export enum GlobalState {
 export enum WorkspaceState {
 	LastBuildState = 'lastRunOptions',
 	LastPackageState = 'lastDistOptions',
-	LastKeystorePath = 'lastKeystorePath',
-
+	LastKeystorePath = 'lastKeystorePath'
 }

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,18 +1,29 @@
 import { ExtensionContext } from 'vscode';
 import appc from './appc';
+import { Config, configuration } from './configuration';
 import Terminal from './terminal';
 
 export class ExtensionContainer {
 	private static _appc;
+	private static _config: Config | undefined;
 	private static _context: ExtensionContext;
 	private static _terminal: Terminal;
-	public static inititalize (context: ExtensionContext) {
+
+	public static inititalize (context: ExtensionContext, config: Config) {
 		this._appc = appc;
+		this._config = config;
 		this._context = context;
 	}
 
 	static get appc () {
 		return this._appc;
+	}
+
+	static get config () {
+		if (this._config === undefined) {
+			this._config = configuration.get<Config>();
+		}
+		return this._config;
 	}
 
 	static get context () {
@@ -26,5 +37,7 @@ export class ExtensionContainer {
 		return this._terminal;
 	}
 
-	// static get
+	public static resetConfig () {
+		this._config = undefined;
+	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,7 @@ import { StyleDefinitionProvider } from './providers/definition/styleDefinitionP
 import { ViewCodeActionProvider } from './providers/definition/viewCodeActionProvider';
 import { ViewDefinitionProvider } from './providers/definition/viewDefinitionProvider';
 import { ViewHoverProvider } from './providers/definition/viewHoverProvider';
+import { LogLevel } from './types/common';
 
 let projectStatusBarItem;
 /**
@@ -106,7 +107,7 @@ function activate (context) {
 
 		// register stop command
 		vscode.commands.registerCommand(Commands.StopBuild, () => {
-			if (vscode.workspace.getConfiguration('titanium.general').get('useTerminalForBuild')) {
+			if (ExtensionContainer.config.general.useTerminalForBuild) {
 				ExtensionContainer.terminal.clear();
 			} else {
 				appc.stop();
@@ -116,8 +117,9 @@ function activate (context) {
 		// register set log level command
 		vscode.commands.registerCommand(Commands.SetLogLevel, async () => {
 			const level = await vscode.window.showQuickPick([ 'Trace', 'Debug', 'Info', 'Warn', 'Error' ], { placeHolder: 'Select log level' });
-			if (level) {
-				ExtensionContainer.context.globalState.update('logLevel', level.toLowerCase());
+			const actualLevel = LogLevel[level];
+			if (actualLevel) {
+				await configuration.update('general.logLevel', actualLevel, vscode.ConfigurationTarget.Global);
 			}
 		}),
 
@@ -151,14 +153,12 @@ function activate (context) {
 		}),
 
 		vscode.commands.registerCommand(Commands.EnableLiveView, async () => {
-			await ExtensionContainer.context.globalState.update('titanium:liveview', true);
-			await vscode.commands.executeCommand('setContext', 'titanium:liveview', true);
+			await configuration.update('build.liveview', true, vscode.ConfigurationTarget.Global);
 			vscode.window.showInformationMessage('Enabled LiveView');
 		}),
 
 		vscode.commands.registerCommand(Commands.DisableLiveView, async () => {
-			await ExtensionContainer.context.globalState.update('titanium:liveview', false);
-			await vscode.commands.executeCommand('setContext', 'titanium:liveview', false);
+			await configuration.update('build.liveview', false, vscode.ConfigurationTarget.Global);
 			vscode.window.showInformationMessage('Disabled LiveView');
 		}),
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import { StyleCompletionItemProvider } from './providers/completion/styleComplet
 import { TiappCompletionItemProvider } from './providers/completion/tiappCompletionItemProvider';
 import { ViewCompletionItemProvider } from './providers/completion/viewCompletionItemProvider';
 
+import { Config, Configuration, configuration } from './configuration';
 import { ControllerDefinitionProvider } from './providers/definition/controllerDefinitionProvider';
 import * as definitionProviderHelper from './providers/definition/definitionProviderHelper';
 import { StyleDefinitionProvider } from './providers/definition/styleDefinitionProvider';
@@ -41,7 +42,12 @@ let projectStatusBarItem;
  * @param {Object} context 	extension context
  */
 function activate (context) {
-	ExtensionContainer.inititalize(context);
+
+	Configuration.configure(context);
+
+	const config = configuration.get<Config>();
+
+	ExtensionContainer.inititalize(context, config);
 	project.load();
 	// definitionProviderHelper.activate(context.subscriptions);
 

--- a/src/providers/completion/alloyAutoCompleteRules.ts
+++ b/src/providers/completion/alloyAutoCompleteRules.ts
@@ -4,6 +4,7 @@ import * as utils from '../../utils';
 
 import { CompletionItemKind, workspace } from 'vscode';
 import { parseString } from 'xml2js';
+import { ExtensionContainer } from '../../container';
 
 export const cfgAutoComplete = {
 	regExp: /Alloy\.CFG\.([-a-zA-Z0-9-_/]*)$/,
@@ -37,7 +38,7 @@ export const cfgAutoComplete = {
 export const i18nAutoComplete = {
 	regExp: /(L\(|titleid\s*[:=]\s*)["'](\w*)$/,
 	async getCompletions () {
-		const defaultLang: string = workspace.getConfiguration('titanium.project').get('defaultI18nLanguage');
+		const defaultLang = ExtensionContainer.config.project.defaultI18nLanguage;
 		const i18nPath = utils.getI18nPath();
 		if (utils.directoryExists(i18nPath)) {
 			const i18nStringPath = path.join(i18nPath, defaultLang, 'strings.xml');

--- a/src/providers/definition/common.ts
+++ b/src/providers/definition/common.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as related from '../../related';
 
 import { workspace } from 'vscode';
+import { ExtensionContainer } from '../../container';
 
 export const viewSuggestions = [
 	{ // class
@@ -20,7 +21,7 @@ export const viewSuggestions = [
 			return `Generate style (${fileName})`;
 		},
 		insertText (text) {
-			let insertText: string = workspace.getConfiguration('titanium.codeTemplates').get('tssClass');
+			let insertText = ExtensionContainer.config.codeTemplates.tssClass;
 			insertText = insertText.replace(/(\${text})/g, text).replace(/\\n/g, '\n');
 			return insertText;
 		}
@@ -40,7 +41,7 @@ export const viewSuggestions = [
 			return `Generate style (${fileName})`;
 		},
 		insertText (text) {
-			let insertText: string = workspace.getConfiguration('titanium.codeTemplates').get('tssId');
+			let insertText = ExtensionContainer.config.codeTemplates.tssId;
 			insertText = insertText.replace(/(\${text})/g, text).replace(/\\n/g, '\n');
 			return insertText;
 		}
@@ -64,7 +65,7 @@ export const viewSuggestions = [
 				|| text.startsWith('/')) {
 				return;
 			}
-			let insertText: string = workspace.getConfiguration('titanium.codeTemplates').get('tssTag');
+			let insertText = ExtensionContainer.config.codeTemplates.tssTag;
 			insertText = insertText.replace(/(\${text})/g, text).replace(/\\n/g, '\n');
 			return insertText;
 		}
@@ -81,7 +82,7 @@ export const viewSuggestions = [
 			return `Generate function (${fileName})`;
 		},
 		insertText (text) {
-			let insertText: string = workspace.getConfiguration('titanium.codeTemplates').get('jsFunction');
+			let insertText = ExtensionContainer.config.codeTemplates.jsFunction;
 			insertText = insertText.replace(/(\${text})/g, text).replace(/\\n/g, '\n');
 			return insertText;
 		}

--- a/src/providers/definition/definitionProviderHelper.ts
+++ b/src/providers/definition/definitionProviderHelper.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as utils from '../../utils';
 
 import { commands, Hover, Location, MarkdownString, Position, Range, Uri, workspace, WorkspaceEdit } from 'vscode';
+import { ExtensionContainer } from '../../container';
 
 /**
  * Definition provider helper
@@ -21,7 +22,7 @@ const i18nSuggestions = [
 			return new RegExp(`name=["']${text}["']>(.*)?</`, 'g');
 		},
 		files () {
-			return [ path.join(utils.getI18nPath(), workspace.getConfiguration('titanium.project').get('defaultI18nLanguage'), 'strings.xml') ];
+			return [ path.join(utils.getI18nPath(), ExtensionContainer.config.project.defaultI18nLanguage, 'strings.xml') ];
 		},
 		i18nString: true
 	}
@@ -241,7 +242,7 @@ export function insert (text, filePath) {
  * @param {String} text text to insert
  */
 export function insertI18nString (text) {
-	const defaultLang: string = workspace.getConfiguration('titanium.project').get('defaultI18nLanguage');
+	const defaultLang =  ExtensionContainer.config.project.defaultI18nLanguage;
 	const i18nStringPath = path.join(utils.getI18nPath(), defaultLang, 'strings.xml');
 	if (!utils.fileExists(i18nStringPath)) {
 		fs.ensureDirSync(path.join(utils.getI18nPath(), defaultLang));

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -42,3 +42,11 @@ export interface ProvisioningProfile {
 	team: string[];
 	uuid: string;
 }
+
+export enum LogLevel {
+	Debug = 'debug',
+	Error = 'error',
+	Info = 'info',
+	Trace = 'trace',
+	Warn = 'warn'
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,0 +1,32 @@
+import { LogLevel } from './common';
+
+export interface Config {
+	android: {
+		keystoreAlias: string,
+		keystorePath: string
+	};
+	build: {
+		liveview: boolean
+	};
+	codeTemplates: {
+		jsFunction: string,
+		tssClass: string,
+		tssId: string,
+		tssTag: string
+	};
+	general: {
+		appcCommandPath: string,
+		displayBuildCommandInConsole: boolean,
+		logLevel: LogLevel,
+		useTerminalForBuild: boolean
+	};
+	ios: {
+		showProvisioningProfileDetail: boolean
+	};
+	package: {
+		distributionOutputDirectory: string
+	};
+	project: {
+		defaultI18nLanguage: string
+	};
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -20,9 +20,6 @@ export interface Config {
 		logLevel: LogLevel,
 		useTerminalForBuild: boolean
 	};
-	ios: {
-		showProvisioningProfileDetail: boolean
-	};
 	package: {
 		distributionOutputDirectory: string
 	};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -143,19 +143,6 @@ export function iOSProvisioinngProfileMatchesAppId (profileAppId: string, appId:
 }
 
 /**
- * Distribution output directory. Builds absolute path.
- *
- * @returns {String}
- */
-export function  distributionOutputDirectory () {
-	const directory: string = workspace.getConfiguration('titanium.package').get('distributionOutputDirectory');
-	if (!path.isAbsolute(directory)) {
-		return path.join(workspace.rootPath, directory);
-	}
-	return directory;
-}
-
-/**
  * Returns string with capitalized first letter
  *
  * @param {String} s - string.
@@ -276,7 +263,8 @@ export function filterJSFiles (directory: string) {
 export function buildArguments (options: any, projectType: string) {
 	const args = [
 		'run',
-		'--platform', options.platform
+		'--platform', options.platform,
+		'--log-level', options.logLevel
 	];
 
 	if (projectType === 'app') {
@@ -297,6 +285,7 @@ export function buildArguments (options: any, projectType: string) {
 			args.push('--liveview');
 		}
 	}
+
 	return args.map(arg => quoteArgument(arg));
 }
 
@@ -304,7 +293,8 @@ export function packageArguments (options: any) {
 	const args = [
 		'run',
 		'--platform', options.platform,
-		'--target', options.target
+		'--target', options.target,
+		'--log-level', options.logLevel
 	];
 
 	if (options.target !== 'dist-appstore') {
@@ -335,7 +325,7 @@ export function createAppArguments (options: any) {
 		'--project-dir', path.join(options.workspaceDir, options.name),
 		'--platforms', options.platforms.join(','),
 		'--no-prompt',
-		'--log-level', 'trace'
+		'--log-level', options.logLevel
 	];
 
 	if (options.force) {
@@ -358,7 +348,7 @@ export function createModuleArguments (options: any) {
 		'--project-dir', path.join(options.workspaceDir, options.name),
 		'--platforms', options.platforms.join(','),
 		'--no-prompt',
-		'--log-level', 'trace'
+		'--log-level', options.logLevel
 	];
 
 	if (options.force) {


### PR DESCRIPTION
This PR refactors the config management of the extension to only get/update settings through the ExtensionContainer class.

It includes the fix for #46