### PR TITLE
fix(package): correct last build state for android

### DIFF
--- a/src/commands/packageApp.ts
+++ b/src/commands/packageApp.ts
@@ -9,6 +9,7 @@ import { nameForPlatform, packageArguments, } from '../utils';
 import { checkLogin, handleInteractionError, InteractionError } from './common';
 
 import { enterAndroidKeystoreInfo, enterPassword, selectDistributionTarget, selectiOSCodeSigning, selectPlatform } from '../quickpicks/common';
+import { KeystoreInfo } from '../types/common';
 
 export async function packageApplication (node: DeviceNode | OSVerNode | PlatformNode | TargetNode) {
 	try {
@@ -19,11 +20,11 @@ export async function packageApplication (node: DeviceNode | OSVerNode | Platfor
 		const logLevel = ExtensionContainer.config.general.logLevel;
 
 		let iOSCertificate;
+		let iOSProvisioningProfile;
+		let keystoreInfo: KeystoreInfo;
 		let lastBuildDescription;
 		let outputDirectory;
-		let keystoreInfo;
 		let platform;
-		let iOSProvisioningProfile;
 		let target;
 
 		if (node) {
@@ -94,10 +95,11 @@ export async function packageApplication (node: DeviceNode | OSVerNode | Platfor
 			iOSProvisioningProfile,
 			logLevel
 		};
-		const storableInfo = Object.assign({}, buildInfo, { keystoreInfo: { password: null }});
-		ExtensionContainer.context.workspaceState.update(WorkspaceState.LastPackageState, storableInfo);
 		const args = packageArguments(buildInfo);
 		ExtensionContainer.terminal.runCommand(args);
+		buildInfo.keystoreInfo.password = null;
+		buildInfo.keystoreInfo.privateKeyPassword = null;
+		ExtensionContainer.context.workspaceState.update(WorkspaceState.LastPackageState, buildInfo);
 	} catch (error) {
 		if (error instanceof InteractionError) {
 			await handleInteractionError(error);

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -12,7 +12,7 @@ export interface RunOptions {
 
 export interface KeystoreInfo {
 	alias: string;
-	path: string;
+	location: string;
 	password: string;
 	privateKeyPassword?: string;
 }
@@ -37,7 +37,7 @@ export interface ProvisioningProfile {
 	expirationDate: string;
 	file: string;
 	getTaskAllow: boolean;
-	managaged: boolean;
+	managed: boolean;
 	name: string;
 	team: string[];
 	uuid: string;


### PR DESCRIPTION
Object.assign is not a deep copy like I thought, just null the passwords out manually on buildInfo before storing

Fixes #47

### Verification steps

1. Package for Android via the command palette
2. Package for last run via the command palette
2. Package for Android via the activity pane