### PR TITLE
feat(config): add support for setting default keystore path

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,12 +234,12 @@
       "properties": {
         "titanium.android.keystoreAlias": {
           "type": "string",
-          "default": "",
+          "default": null,
           "description": "Keystore alias used for packaging Android applications"
         },
         "titanium.android.keystorePath": {
           "type": "string",
-          "default": "",
+          "default": null,
           "description": "Path to keystore used for packaging Android applications"
         },
         "titanium.build.liveview": {

--- a/src/commands/packageApp.ts
+++ b/src/commands/packageApp.ts
@@ -65,8 +65,9 @@ export async function packageApplication (node: DeviceNode | OSVerNode | Platfor
 
 		if (platform === 'android' && !keystoreInfo) {
 			const lastKeystore = ExtensionContainer.context.workspaceState.get<string>(WorkspaceState.LastKeystorePath);
+			const savedKeystorePath = ExtensionContainer.config.android.keystorePath;
 			// TODO: Private key password?
-			keystoreInfo = await enterAndroidKeystoreInfo(lastKeystore);
+			keystoreInfo = await enterAndroidKeystoreInfo(lastKeystore, savedKeystorePath);
 			ExtensionContainer.context.workspaceState.update(WorkspaceState.LastKeystorePath, keystoreInfo.location);
 		} else if (platform === 'ios' && !iOSCertificate) {
 			const codesigning = await selectiOSCodeSigning(buildType, target, project.appId());

--- a/src/quickpicks/common.ts
+++ b/src/quickpicks/common.ts
@@ -1,8 +1,10 @@
 import appc from '../appc';
 import * as utils from '../utils';
 
+import { pathExists } from 'fs-extra';
 import { InputBoxOptions, OpenDialogOptions, QuickPickOptions, window } from 'vscode';
-import { UserCancellation } from '../commands/common';
+import { InteractionError, UserCancellation } from '../commands/common';
+import { ExtensionContainer } from '../container';
 
 export async function selectFromFileSystem (options: OpenDialogOptions) {
 	if (!options.canSelectMany) {
@@ -111,7 +113,7 @@ export function selectAndroidEmulator () {
 	return quickPick(options, { placeHolder: 'Select emulator' });
 }
 
-export async function selectAndroidKeystore (lastUsed) {
+export async function selectAndroidKeystore (lastUsed, savedKeystorePath) {
 	const items = [{
 		label: 'Browse for keystore',
 		id: 'browse'
@@ -122,18 +124,30 @@ export async function selectAndroidKeystore (lastUsed) {
 			id: 'last'
 		});
 	}
+	if (savedKeystorePath) {
+		items.push({
+			label: `Saved ${savedKeystorePath}`,
+			id: 'saved'
+		});
+	}
 	const keystoreAction = await quickPick(items, { placeHolder: 'Browse for keystore or use last keystore' });
 	if (keystoreAction.id === 'browse') {
 		const uri = await window.showOpenDialog({ canSelectFolders: false, canSelectMany: false });
 		return uri[0].path;
+	} else if (keystoreAction.id === 'saved') {
+			return savedKeystorePath;
 	} else {
 		return lastUsed;
 	}
 }
 
-export async function enterAndroidKeystoreInfo (lastUsed) {
-	const location = await selectAndroidKeystore(lastUsed);
-	const alias = await inputBox({ placeHolder: 'Enter your keystore alias' });
+export async function enterAndroidKeystoreInfo (lastUsed, savedKeystorePath) {
+	const location = await selectAndroidKeystore(lastUsed, savedKeystorePath);
+
+	if (!await pathExists(location)) {
+		throw new InteractionError('The Keystore files does not exist');
+	}
+	const alias = await inputBox({ placeHolder: 'Enter your keystore alias', value: ExtensionContainer.config.android.keystoreAlias });
 	const password = await enterPassword({ placeHolder: 'Enter your keystore password' });
 	return {
 		alias,

--- a/src/quickpicks/common.ts
+++ b/src/quickpicks/common.ts
@@ -1,8 +1,9 @@
+import * as path from 'path';
 import appc from '../appc';
 import * as utils from '../utils';
 
 import { pathExists } from 'fs-extra';
-import { InputBoxOptions, OpenDialogOptions, QuickPickOptions, window } from 'vscode';
+import { InputBoxOptions, OpenDialogOptions, QuickPickOptions, window, workspace } from 'vscode';
 import { InteractionError, UserCancellation } from '../commands/common';
 import { ExtensionContainer } from '../container';
 
@@ -135,7 +136,10 @@ export async function selectAndroidKeystore (lastUsed, savedKeystorePath) {
 		const uri = await window.showOpenDialog({ canSelectFolders: false, canSelectMany: false });
 		return uri[0].path;
 	} else if (keystoreAction.id === 'saved') {
-			return savedKeystorePath;
+		if (!path.isAbsolute(savedKeystorePath)) {
+			savedKeystorePath = path.resolve(workspace.rootPath, savedKeystorePath);
+		}
+		return savedKeystorePath;
 	} else {
 		return lastUsed;
 	}
@@ -145,7 +149,7 @@ export async function enterAndroidKeystoreInfo (lastUsed, savedKeystorePath) {
 	const location = await selectAndroidKeystore(lastUsed, savedKeystorePath);
 
 	if (!await pathExists(location)) {
-		throw new InteractionError('The Keystore files does not exist');
+		throw new InteractionError(`The Keystore file ${location} does not exist`);
 	}
 	const alias = await inputBox({ placeHolder: 'Enter your keystore alias', value: ExtensionContainer.config.android.keystoreAlias });
 	const password = await enterPassword({ placeHolder: 'Enter your keystore password' });

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -2,8 +2,8 @@ import { LogLevel } from './common';
 
 export interface Config {
 	android: {
-		keystoreAlias: string,
-		keystorePath: string
+		keystoreAlias: string | null,
+		keystorePath: string | null
 	};
 	build: {
 		liveview: boolean


### PR DESCRIPTION
Allows the user to have the keystore path and alias saved in the settings.json.

Fixes #51 

### Verification steps

1. Add settings `titanium.android.keystorePath` and or `titanium.android.keystoreAlias` to the .vscode settings file
2. Package an to an android application using the saved keystore path