### PR TITLE
fix(textmate): fixed syntax highlight for alloy.cfg

### DIFF
--- a/grammars/tss.JSON-tmLanguage.json
+++ b/grammars/tss.JSON-tmLanguage.json
@@ -67,6 +67,20 @@
               "match": "android|ios|Alloy\\.Globals\\."
             }
           ]
+        },
+        {
+          "name": "entity.name.tag.css.tss",
+          "begin": "\\[",
+          "end": "\\]",
+          "patterns": [{
+              "name": "variable.interpolation.tss",
+              "match": "(platform|if)\\="
+            },
+            {
+              "name": "meta.link.tss",
+              "match": "android|ios|Alloy\\.CFG\\."
+            }
+          ]
         }
       ]
     },
@@ -325,6 +339,11 @@
         {
           "name": "support.class.tss.alloyglobals",
           "begin": "Alloy\\.Globals",
+          "end": "(?=[,\\}\\]\\n\\r])"
+        },
+        {
+          "name": "support.class.tss.alloyCFG",
+          "begin": "Alloy\\.CFG",
           "end": "(?=[,\\}\\]\\n\\r])"
         },
         {


### PR DESCRIPTION
Fixed the syntax highlighting for Alloy.CFG to highlight the same as Alloy.Globals

Fixes #103