### PR TITLE
fix: ensure correct drive letter is used when normalizing path

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -430,6 +430,6 @@ function normalizeDriveLetter (filePath: string): string {
 	if (process.platform !== 'win32') {
 		return filePath;
 	}
-	const rootDir = path.resolve('/');
-	return `${rootDir.substr(0, 1)}${filePath.slice(1)}`;
+	const { root } = path.parse(filePath);
+	return `${root.substr(0, 1).toUpperCase()}${filePath.slice(1)}`;
 }


### PR DESCRIPTION
We need to ensure the drive letter is uppercased to prevent an infinite loop in the SDK build process

Fixes #142