### PR TITLE
fix: fixed value completions in tss and views with word fragment

### DIFF
--- a/src/providers/completion/styleCompletionItemProvider.ts
+++ b/src/providers/completion/styleCompletionItemProvider.ts
@@ -42,7 +42,7 @@ export class StyleCompletionItemProvider implements CompletionItemProvider {
 			if (ruleResult) {
 				return ruleResult;
 			} else {
-				return this.getPropertyValueCompletions(linePrefix, prefix);
+				return this.getPropertyValueCompletions(linePrefix, prefix, position, document);
 			}
 		// property name - _ or fo_
 		} else if (/^\s*\w*$/.test(linePrefix)) {
@@ -194,8 +194,9 @@ export class StyleCompletionItemProvider implements CompletionItemProvider {
 	 *
 	 * @returns {Array}
 	 */
-	public getPropertyValueCompletions (linePrefix, prefix) {
+	public getPropertyValueCompletions (linePrefix, prefix, position, document) {
 		const { properties } = this.completions.titanium;
+		const range = document.getWordRangeAtPosition(position, /([\w\"\.\'\$]+)/);
 		let property;
 		const matches = /^\s*(\S+)\s*:/.exec(linePrefix);
 		if (matches && matches.length >= 2) {
@@ -216,6 +217,7 @@ export class StyleCompletionItemProvider implements CompletionItemProvider {
 			if (!prefix || utils.matches(value, prefix)) {
 				completions.push({
 					label: value,
+					range,
 					kind: CompletionItemKind.Value
 				});
 			}

--- a/src/providers/completion/styleCompletionItemProvider.ts
+++ b/src/providers/completion/styleCompletionItemProvider.ts
@@ -191,12 +191,14 @@ export class StyleCompletionItemProvider implements CompletionItemProvider {
 	 *
 	 * @param {String} linePrefix line prefix text
 	 * @param {String} prefix word prefix text
+	 * @param {Position} position caret position
+	 * @param {TextDocument} document active text document
 	 *
 	 * @returns {Array}
 	 */
 	public getPropertyValueCompletions (linePrefix, prefix, position, document) {
 		const { properties } = this.completions.titanium;
-		const range = document.getWordRangeAtPosition(position, /([\w\"\.\'\$]+)/);
+		const range = document.getWordRangeAtPosition(position, /([\w".'\$]+)/);
 		let property;
 		const matches = /^\s*(\S+)\s*:/.exec(linePrefix);
 		if (matches && matches.length >= 2) {

--- a/src/providers/completion/viewCompletionItemProvider.ts
+++ b/src/providers/completion/viewCompletionItemProvider.ts
@@ -167,6 +167,7 @@ export class ViewCompletionItemProvider implements CompletionItemProvider {
 		let values;
 		let tag;
 		const matches = linePrefix.match(/<([a-zA-Z][-a-zA-Z]*)(?:\s|$)/);
+		const range = document.getWordRangeAtPosition(position, /([\w.\$]+)/);
 		if (matches) {
 			tag = matches[1];
 		}
@@ -261,6 +262,7 @@ export class ViewCompletionItemProvider implements CompletionItemProvider {
 				if (!prefix || utils.matches(value, prefix)) {
 					completions.push({
 						label: value,
+						range,
 						kind: CompletionItemKind.Value
 					});
 				}


### PR DESCRIPTION
Fixed the completions in tss files where the completions would not take into account the word
fragment already there.

fixes #150