### PR TITLE
fix(commands/run): only do certificate name check when targeting device

### DIFF
--- a/src/commands/buildApp.ts
+++ b/src/commands/buildApp.ts
@@ -70,9 +70,11 @@ export async function buildApplication (node: DeviceNode | OSVerNode | PlatformN
 				platform = lastBuildState.platform as Platform;
 				target = lastBuildState.target;
 				if (platform === Platform.ios) {
-					iOSCertificate = getCorrectCertificateName((lastBuildState as BuildIosAppOptions).iOSCertificate!, project.sdk()[0], IosCertificateType.developer);
 					osVersion = (lastBuildState as BuildIosAppOptions & { osVersion: string }).osVersion;
-					iOSProvisioningProfile = (lastBuildState as BuildIosAppOptions).iOSProvisioningProfile;
+					if (target === 'device') {
+						iOSCertificate = getCorrectCertificateName((lastBuildState as BuildIosAppOptions).iOSCertificate!, project.sdk()[0], IosCertificateType.developer);
+						iOSProvisioningProfile = (lastBuildState as BuildIosAppOptions).iOSProvisioningProfile;
+					}
 				}
 
 			} else {


### PR DESCRIPTION
To repro:

1. Build to a simulator following the usual prompting
2. Perform another build and select the `Last build` option (should be the last simulator you chose), it should work