### PR TITLE
fix(debugging/android): correctly assign default port

### DIFF
--- a/src/debugger/titaniumDebugConfigurationProvider.ts
+++ b/src/debugger/titaniumDebugConfigurationProvider.ts
@@ -21,8 +21,9 @@ export class TitaniumDebugConfigurationProvider implements vscode.DebugConfigura
 
 		if (!ourConfig.port) {
 			ourConfig.port = 9000;
+			ourConfig.debugPort = 9000;
 		} else {
-			config.debugPort = config.port;
+			ourConfig.debugPort = ourConfig.port;
 		}
 
 		try {


### PR DESCRIPTION
To test:

1. Debug for Android - it should actually work 