### PR TITLE
refactor(debugger)!: use tasks for building application

### DIFF
--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -24,28 +24,20 @@ To debug Titanium applications from VS Code you must first create a debug config
 3. Select `Titanium` from the environment selection list
     ![Debug Environment Selection](./images/EnvironmentSelect.png)
 
-This will automatically generate two debug configurations in `.vscode/launch.json` file, one to debug on Android, one to debug on iOS. You can customise these files using the following properties
+This will automatically generate two debug configurations in `.vscode/launch.json` file, one to debug on Android, one to debug on iOS. You can customise these files using the following properties.
 
 | Property name | Description | Default value |
 | ------------- | ------------| ------------- |
-| deviceId | Device ID of the device to debug to | No Default |
 | platform | Platform to debug | No Default |
-| projectDir | Directory of the Titanium project being debugged | [${workspaceFolder}](https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables) |
+| projectDir | Directory of the Titanium project to debug | [${workspaceFolder}](https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables) |
 | port | Port number to use for the debugger | 9000 |
-| target | Build target to debug on | No Default |
+| preLaunchTask | Name of the task to use to build the application | No Default |
 
-For example if you commonly debug on the same iOS device you could create a debug configuration like below in your `launch.json` file:
+## Specifying a prelaunch task
 
-```json
-    {
-        "name": "Launch on iOS device - my iPhone",
-        "type": "titanium",
-        "request": "launch",
-        "platform": "ios",
-        "target": "device",
-        "deviceId": "<device ID from info>"
-    }
-```
+The `preLaunchTask` property allows setting a task from the `.vscode/tasks.json` file to be used to build the application. This allows you to declare the target and device ID for your build so you won't be prompted for these every build. For documentation on configuring tasks see the [tasks documentation](./tasks.md).
+
+If no `preLaunchTask` is specified, then a default task is created and added to the `.vscode/tasks.json` file for you which is then reused when debugging in future. When using these tasks you will be prompted for the target and device ID every build.
 
 ## Debugging an application
 

--- a/package.json
+++ b/package.json
@@ -134,14 +134,6 @@
               "port": {
                 "type": "number",
                 "description": "Port number to use for the debugger"
-              },
-              "deviceId": {
-                "type": "string",
-                "description": "Device ID of the device to debug to"
-              },
-              "target": {
-                "type": "string",
-                "description": "Build target to debug on"
               }
             }
           }
@@ -835,6 +827,27 @@
                 ]
               }
             }
+          }
+        }
+      }
+    ],
+    "problemMatchers": [
+      {
+        "name": "ti-app-launch",
+        "label": "Detects an app launch",
+        "owner": "titanium",
+        "source": "titanium",
+        "applyTo": "allDocuments",
+        "pattern": {
+          "regexp": "__________"
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": {
+            "regexp": "__________"
+          },
+          "endsPattern": {
+            "regexp": "Start (application|simulator) log"
           }
         }
       }

--- a/src/common/extensionProtocol.ts
+++ b/src/common/extensionProtocol.ts
@@ -1,5 +1,6 @@
 import { IAttachRequestArgs, ILaunchRequestArgs } from '@awam/vscode-chrome-debug-core';
-import { LogLevel, Platform } from '../types/common';
+import { LogLevel } from '../types/common';
+import { Platform } from '../tasks/tasksHelper';
 
 export interface Request {
 	id: string;
@@ -27,6 +28,7 @@ export interface TitaniumLaunchRequestArgs extends ILaunchRequestArgs {
 	cwd: string;
 	appName: string;
 	logLevel: LogLevel;
+	preLaunchTask: string;
 }
 
 export interface TitaniumAttachRequestArgs extends IAttachRequestArgs {

--- a/src/debugger/titaniumDebugConfigurationProvider.ts
+++ b/src/debugger/titaniumDebugConfigurationProvider.ts
@@ -2,12 +2,21 @@ import * as getPort from 'get-port';
 import * as vscode from 'vscode';
 import * as which from 'which';
 import { UserCancellation } from '../commands';
-import { WorkspaceState } from '../constants';
-import { ExtensionContainer } from '../container';
-import project from '../project';
-import { quickPick, selectDevice, selectiOSCertificate, selectiOSProvisioningProfile, selectPlatform } from '../quickpicks/common';
-import { getCorrectCertificateName, nameForTarget, targetsForPlatform } from '../utils';
-import { IosCertificateType } from '../types/common';
+import { selectPlatform } from '../quickpicks/common';
+import { AppBuildTaskDefinitionBase } from '../tasks/buildTaskProvider';
+import { addTask, getTasks } from '../tasks/tasksHelper';
+import { TitaniumTaskDefinitionBase } from '../tasks/commandTaskProvider';
+
+function validateTask (task: TitaniumTaskDefinitionBase, ourConfig: vscode.DebugConfiguration): void {
+	// TODO: investigate whether it is possible to update the task
+	if (ourConfig.platform && ourConfig.platform !== task.titaniumBuild.platform) {
+		throw new Error('Debug configuration platform and preLaunchTask platform do not match');
+	} else if (!task.problemMatcher || !task.problemMatcher.includes('$ti-app-launch')) {
+		throw new Error(`Pre-launch task "${task.label}" requires the "$ti-app-launch" problem matcher to be set`);
+	} else if (!task.isBackground) {
+		throw new Error(`Pre-launch task "${task.label}" requires "isBackground" to be set to true`);
+	}
+}
 
 export class TitaniumDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 
@@ -15,6 +24,7 @@ export class TitaniumDebugConfigurationProvider implements vscode.DebugConfigura
 		if (!config.projectDir) {
 			config.projectDir = '${workspaceFolder}'; // eslint-disable-line no-template-curly-in-string
 		}
+
 		const ourConfig: vscode.DebugConfiguration = {
 			...config
 		};
@@ -35,9 +45,19 @@ export class TitaniumDebugConfigurationProvider implements vscode.DebugConfigura
 			throw new Error('Failed to start debug session as could not find a free port. Please set a "port" value in your debug configuration.');
 		}
 
-		if (!ourConfig.logLevel) {
-			ourConfig.logLevel = ExtensionContainer.config.general.logLevel;
+		if (config.preLaunchTask) {
+			const preLaunchTask = getTasks(vscode.workspace.rootPath!).find(task => task.label === config.preLaunchTask);
 
+			if (!preLaunchTask) {
+				throw new Error(`Unable to find a preLaunchTask named ${config.preLaunchTask}`);
+			}
+
+			validateTask(preLaunchTask, ourConfig);
+
+			if (!ourConfig.platform) {
+				// If no platform is set then inherit from the task
+				ourConfig.platform = preLaunchTask.definition.titaniumBuild.platform;
+			}
 		}
 
 		if (!ourConfig.platform) {
@@ -72,85 +92,30 @@ export class TitaniumDebugConfigurationProvider implements vscode.DebugConfigura
 			}
 		}
 
-		if (!ourConfig.target) {
-			try {
-				let lastDebugState;
-				if (ourConfig.platform === 'android') {
-					lastDebugState = ExtensionContainer.context.workspaceState.get<vscode.DebugConfiguration>(WorkspaceState.LastAndroidDebug);
-				} else if (ourConfig.platform === 'ios') {
-					lastDebugState = ExtensionContainer.context.workspaceState.get<vscode.DebugConfiguration>(WorkspaceState.LastiOSDebug);
-				}
+		if (!ourConfig.preLaunchTask) {
+			const taskName = `Titanium Debug - ${ourConfig.platform}`;
+			const existingTask = getTasks(vscode.workspace.rootPath!).find(task => task.label === taskName);
 
-				const targets = targetsForPlatform(ourConfig.platform)
-					.filter(target => !/^dist/.test(target))
-					.map(target => ({ label: nameForTarget(target), id: target }));
+			if (!existingTask) {
+				const task: AppBuildTaskDefinitionBase = {
+					type: 'titanium-build',
+					label: taskName,
+					titaniumBuild: {
+						projectType: 'app',
+						platform: ourConfig.platform,
+						projectDir: vscode.workspace.rootPath!,
+						debugPort: ourConfig.debugPort
+					},
+					problemMatcher: [ '$ti-app-launch' ],
+					isBackground: true
+				};
 
-				if (lastDebugState) {
-					try {
-						targets.push({
-							label: `Last debug session (${lastDebugState.target} - ${lastDebugState.deviceName})`,
-							id: 'last'
-						});
-					} catch (error) {
-						// squelch error as it might be due to bad last state
-						lastDebugState = undefined;
-					}
-				}
-				const targetInfo = await quickPick(targets);
-				if (lastDebugState && targetInfo.id === 'last') {
-					ourConfig.target = lastDebugState.target;
-					ourConfig.deviceId = lastDebugState.deviceId;
-					ourConfig.deviceName = lastDebugState.deviceName;
-					ourConfig.iOSCertificate = lastDebugState.iOSCertificate;
-					ourConfig.iOSProvisioningProfile = lastDebugState.iOSProvisioningProfile;
-				} else {
-					ourConfig.target = targetInfo.id;
-				}
-			} catch (error) {
-				let message = error.message;
-				if (error instanceof UserCancellation) {
-					message = 'Failed to start debug session as no target was selected';
-				}
-				throw new Error(message);
+				await addTask(task, vscode.workspace.rootPath!);
+				ourConfig.preLaunchTask = task.label;
+			} else {
+				validateTask(existingTask, ourConfig);
+				ourConfig.preLaunchTask = existingTask.label;
 			}
-		}
-
-		if (!ourConfig.deviceId) {
-			try {
-				const deviceInfo = await selectDevice(ourConfig.platform, ourConfig.target);
-				ourConfig.deviceId = deviceInfo.udid;
-				ourConfig.deviceName = deviceInfo.label;
-			} catch (error) {
-				let message = error.message;
-				if (error instanceof UserCancellation) {
-					message = 'Failed to start debug session as no device was selected';
-				}
-				throw new Error(message);
-			}
-		}
-
-		if (ourConfig.platform === 'ios' && ourConfig.target === 'device' && ourConfig.request !== 'attach') {
-			if (!ourConfig.iOSCertificate) {
-				try {
-					const certificate = await selectiOSCertificate('run');
-					const provisioning = await selectiOSProvisioningProfile(certificate, ourConfig.target, project.appId()!);
-
-					ourConfig.iOSCertificate = getCorrectCertificateName(certificate.label, project.sdk()[0], IosCertificateType.developer);
-					ourConfig.iOSProvisioningProfile = provisioning.uuid;
-				} catch (error) {
-					let message = error.message;
-					if (error instanceof UserCancellation) {
-						message = 'Failed to start debug session as no code signing information was selected';
-					}
-					throw new Error(message);
-				}
-			}
-		}
-
-		if (ourConfig.platform === 'android') {
-			ExtensionContainer.context.workspaceState.update(WorkspaceState.LastAndroidDebug, ourConfig);
-		} else if (ourConfig.platform === 'ios') {
-			ExtensionContainer.context.workspaceState.update(WorkspaceState.LastiOSDebug, ourConfig);
 		}
 
 		return ourConfig;

--- a/src/debugger/titaniumDebugHelper.ts
+++ b/src/debugger/titaniumDebugHelper.ts
@@ -1,0 +1,96 @@
+import * as vscode from 'vscode';
+import { TitaniumDebugConfigurationProvider } from './titaniumDebugConfigurationProvider';
+import { MESSAGE_STRING, Request, TitaniumLaunchRequestArgs, FeedbackOptions, Response } from '../common/extensionProtocol';
+import { BuildAppOptions } from '../types/cli';
+import { ExtensionContainer } from '../container';
+import appc from '../appc';
+import {  runningTasks } from '../tasks/tasksHelper';
+import { Commands } from '../commands';
+
+async function handleCustomEvent(event: vscode.DebugSessionCustomEvent): Promise<void> {
+	if (event.event === MESSAGE_STRING) {
+		const request: Request = event.body;
+
+		if (request.code === 'BUILD') {
+			const providedArgs = request.args as TitaniumLaunchRequestArgs;
+			const response: Response = {
+				id: request.id,
+				result: {
+					isError: false
+				}
+			};
+
+			const runningTask = runningTasks.get(providedArgs.preLaunchTask);
+
+			if (!runningTask) {
+				response.result.isError = true;
+				response.result.message = 'Unable to find running task';
+				event.session.customRequest('extensionResponse', response);
+				return;
+			}
+
+			response.result.buildInfo = runningTask.buildOptions;
+
+			event.session.customRequest('extensionResponse', response);
+		} else if (request.code === 'FEEDBACK') {
+			const feedback = request.args as FeedbackOptions;
+			switch (feedback.type) {
+				case 'error':
+					await vscode.window.showErrorMessage(feedback.message);
+					break;
+				case 'info':
+				default:
+					await vscode.window.showInformationMessage(feedback.message);
+					break;
+			}
+		} else if (request.code === 'END') {
+			const providedArgs = request.args as BuildAppOptions & TitaniumLaunchRequestArgs;
+			await vscode.commands.executeCommand(Commands.StopBuild);
+
+			if (providedArgs.platform !== 'android') {
+				return;
+			}
+
+			const adbPath = appc.getAdbPath();
+			if (!adbPath) {
+				return;
+			}
+
+			const tcpPort = `tcp:${providedArgs.port}`;
+
+			if (providedArgs.target === 'emulator') {
+				const { stdout } = await ExtensionContainer.terminal.runInBackground(adbPath, [ 'forward', '--list' ]);
+
+				for (const line of stdout.split('\n')) {
+					if (!line.includes(tcpPort)) {
+						continue;
+					}
+					const emulatorId = line.match(/emulator-\d+/);
+					if (emulatorId) {
+						providedArgs.deviceId = emulatorId[0];
+						break;
+					}
+				}
+			}
+			if (!providedArgs.deviceId) {
+				return;
+			}
+			try {
+				ExtensionContainer.terminal.runInBackground(adbPath, [ '-s', providedArgs.deviceId, 'forward', '--remove', tcpPort ]);
+			} catch (error) {
+				// squash
+			}
+		}
+	}
+}
+
+export function registerDebugProvider (ctx: vscode.ExtensionContext): void {
+
+	ctx.subscriptions.push(
+		vscode.debug.registerDebugConfigurationProvider('titanium', new TitaniumDebugConfigurationProvider())
+	);
+
+	vscode.debug.onDidReceiveDebugSessionCustomEvent(handleCustomEvent);
+
+}
+

--- a/src/debugger/titaniumSourceMapTransformer.ts
+++ b/src/debugger/titaniumSourceMapTransformer.ts
@@ -11,18 +11,18 @@ export class TitaniumSourceMapTransformer extends BaseSourceMapTransformer {
 	private projectType!: string;
 
 	public async attach (args: TitaniumAttachRequestArgs): Promise<void> {
-		await this.configureOptions(args);
+		await this.configureOptions(args.projectDir, args.platform);
 		return super.attach(args);
 	}
 
 	public async launch (args: TitaniumLaunchRequestArgs): Promise<void> {
-		await this.configureOptions(args);
+		await this.configureOptions(args.projectDir, args.platform);
 		return super.attach(args);
 	}
 
-	public async configureOptions (args: TitaniumLaunchRequestArgs): Promise<void> {
-		this.appDirectory = args.projectDir;
-		this.platform = args.platform;
+	public async configureOptions (projectDir: string, platform: string): Promise<void> {
+		this.appDirectory = projectDir;
+		this.platform = platform;
 		this.projectType = await determineProjectType(this.appDirectory);
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,16 +29,13 @@ import { StyleCompletionItemProvider } from './providers/completion/styleComplet
 import { TiappCompletionItemProvider } from './providers/completion/tiappCompletionItemProvider';
 import { ViewCompletionItemProvider } from './providers/completion/viewCompletionItemProvider';
 
-import { FeedbackOptions, MESSAGE_STRING, Request, Response, TitaniumLaunchRequestArgs } from './common/extensionProtocol';
 import { Config, Configuration, configuration } from './configuration';
 import { ControllerDefinitionProvider } from './providers/definition/controllerDefinitionProvider';
 import { StyleDefinitionProvider } from './providers/definition/styleDefinitionProvider';
 import { ViewCodeActionProvider } from './providers/definition/viewCodeActionProvider';
 import { ViewDefinitionProvider } from './providers/definition/viewDefinitionProvider';
 import { ViewHoverProvider } from './providers/definition/viewHoverProvider';
-import { BuildAppOptions } from './types/cli';
 import { LogLevel, UpdateChoice } from './types/common';
-import { buildArguments } from './utils';
 
 import ms = require('ms');
 import { completion, environment, updates } from 'titanium-editor-commons';
@@ -49,9 +46,9 @@ import { quickPick, selectUpdates } from './quickpicks/common';
 let projectStatusBarItem: vscode.StatusBarItem;
 
 import { UpdateInfo } from 'titanium-editor-commons/updates';
-import { TitaniumDebugConfigurationProvider } from './debugger/titaniumDebugConfigurationProvider';
 
 import { registerTaskProviders } from './tasks/tasksHelper';
+import { registerDebugProvider } from './debugger/titaniumDebugHelper';
 
 function activate (context: vscode.ExtensionContext): Promise<void> {
 
@@ -285,107 +282,13 @@ function activate (context: vscode.ExtensionContext): Promise<void> {
 				// TODO: add some sort of error reporting
 			}
 		}),
-		vscode.commands.registerCommand(Commands.Clean, cleanApplication),
 
-		vscode.debug.onDidReceiveDebugSessionCustomEvent(async event => {
-			if (event.event === MESSAGE_STRING) {
-				const request: Request = event.body;
-
-				if (request.code === 'BUILD') {
-					const providedArgs = request.args as BuildAppOptions & TitaniumLaunchRequestArgs;
-					const response: Response = {
-						id: request.id,
-						result: {
-							isError: false
-						}
-					};
-
-					const buildArgs = buildArguments(providedArgs);
-					const build = ExtensionContainer.terminal.runCommandInOutput(buildArgs, providedArgs.projectDir);
-					if (!build) {
-						return;
-					}
-					build.stdout.on('data', data => {
-						data = data.toString();
-
-						if (providedArgs.platform === 'ios' && /Start (application|simulator) log/.test(data)) {
-							event.session.customRequest('extensionResponse', response);
-						}
-					});
-
-					build.stderr.on('data', data => {
-						data = data.toString();
-						if (providedArgs.platform === 'android' && /To connect Chrome DevTools/.test(data)) {
-							event.session.customRequest('extensionResponse', response);
-						}
-					});
-
-					build.on('exit', code => {
-						if (code) {
-							const message = 'Failed to start debug sessions, please see the output for more information';
-							vscode.window.showErrorMessage(message);
-							ExtensionContainer.terminal.showOutput();
-							response.result = {
-								isError: true,
-								message
-							};
-							event.session.customRequest('extensionResponse', response);
-						}
-					});
-				} else if (request.code === 'FEEDBACK') {
-					const feedback = request.args as FeedbackOptions;
-					switch (feedback.type) {
-						case 'error':
-							await vscode.window.showErrorMessage(feedback.message);
-							break;
-						case 'info':
-						default:
-							await vscode.window.showInformationMessage(feedback.message);
-							break;
-					}
-				} else if (request.code === 'END') {
-					const providedArgs = request.args as BuildAppOptions & TitaniumLaunchRequestArgs;
-					ExtensionContainer.terminal.stop();
-					if (providedArgs.platform !== 'android') {
-						return;
-					}
-					const adbPath = appc.getAdbPath();
-					if (!adbPath) {
-						return;
-					}
-					const tcpPort = `tcp:${providedArgs.port}`;
-
-					if (providedArgs.target === 'emulator') {
-						const { stdout } = await ExtensionContainer.terminal.runInBackground(adbPath, [ 'forward', '--list' ]);
-
-						for (const line of stdout.split('\n')) {
-							if (!line.includes(tcpPort)) {
-								continue;
-							}
-							const emulatorId = line.match(/emulator-\d+/);
-							if (emulatorId) {
-								providedArgs.deviceId = emulatorId[0];
-								break;
-							}
-						}
-					}
-					if (!providedArgs.deviceId) {
-						return;
-					}
-					try {
-						ExtensionContainer.terminal.runInBackground(adbPath, [ '-s', providedArgs.deviceId, 'forward', '--remove', tcpPort ]);
-					} catch (error) {
-						// squash
-					}
-				}
-			}
-		}),
-
-		vscode.debug.registerDebugConfigurationProvider('titanium', new TitaniumDebugConfigurationProvider())
-
+		vscode.commands.registerCommand(Commands.Clean, cleanApplication)
 	);
 
 	registerTaskProviders(context);
+
+	registerDebugProvider(context);
 
 	return init();
 }

--- a/src/tasks/buildTaskProvider.ts
+++ b/src/tasks/buildTaskProvider.ts
@@ -2,10 +2,8 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { CommandTaskProvider, TitaniumTaskBase, TitaniumTaskDefinitionBase, TitaniumBuildBase } from './commandTaskProvider';
 import { selectBuildTarget } from '../quickpicks/common';
-import { TaskExecutionContext, Platform, ProjectType } from './tasksHelper';
+import { TaskExecutionContext } from './tasksHelper';
 import { Helpers } from './helpers/';
-import { TaskPseudoTerminal } from './taskPseudoTerminal';
-import project from '../project';
 
 export interface BuildTask extends TitaniumTaskBase {
 	definition: BuildTaskDefinitionBase;
@@ -34,6 +32,7 @@ export interface AppBuildTaskTitaniumBuildBase extends BuildTaskTitaniumBuildBas
 	projectType?: 'app';
 	liveview?: boolean;
 	deployType?: 'development' | 'test';
+	debugPort?: number;
 }
 
 export interface ModuleBuildTaskTitaniumBuildBase extends BuildTaskTitaniumBuildBase {

--- a/src/tasks/helpers/android.ts
+++ b/src/tasks/helpers/android.ts
@@ -1,4 +1,4 @@
-import { TaskExecutionContext } from '../tasksHelper';
+import { TaskExecutionContext, runningTasks } from '../tasksHelper';
 import { TaskHelper } from './base';
 import { CommandBuilder } from '../commandBuilder';
 import { selectAndroidDevice, selectAndroidEmulator, selectAndroidKeystore, inputBox, enterPassword } from '../../quickpicks/common';
@@ -67,6 +67,7 @@ export class AndroidHelper extends TaskHelper {
 		}
 
 		this.storeLastState(WorkspaceState.LastBuildState, definition);
+		runningTasks.set(context.label, { buildOptions: definition });
 
 		return builder.resolve();
 	}

--- a/src/tasks/helpers/base.ts
+++ b/src/tasks/helpers/base.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { UserCancellation } from '../../commands/common';
 import { BuildTaskTitaniumBuildBase, AppBuildTaskTitaniumBuildBase } from '../buildTaskProvider';
 import { PackageTaskTitaniumBuildBase, AppPackageTaskTitaniumBuildBase } from '../packageTaskProvider';
-import { TitaniumBuildBase, TitaniumTaskDefinitionBase } from '../commandTaskProvider';
+import { TitaniumBuildBase } from '../commandTaskProvider';
 import project from '../../project';
 import { WorkspaceState } from '../../constants';
 

--- a/src/tasks/helpers/ios.ts
+++ b/src/tasks/helpers/ios.ts
@@ -1,5 +1,5 @@
-import { TaskExecutionContext } from '../tasksHelper';
-import { selectiOSDevice, selectiOSSimulator, selectiOSCodeSigning, selectiOSCertificate } from '../../quickpicks';
+import { TaskExecutionContext, runningTasks } from '../tasksHelper';
+import { selectiOSDevice, selectiOSSimulator, selectiOSCertificate } from '../../quickpicks';
 import { getCorrectCertificateName } from '../../utils';
 import project from '../../project';
 import { IosCertificateType, IosCert } from '../../types/common';
@@ -91,6 +91,7 @@ export class IosHelper extends TaskHelper {
 		}
 
 		this.storeLastState(WorkspaceState.LastBuildState, definition);
+		runningTasks.set(context.label, { buildOptions: definition });
 
 		return builder.resolve();
 	}

--- a/src/tasks/tasksHelper.ts
+++ b/src/tasks/tasksHelper.ts
@@ -1,12 +1,10 @@
 import * as vscode from 'vscode';
-import { BuildTaskProvider } from './buildTaskProvider';
+import { BuildTaskProvider, AppBuildTaskTitaniumBuildBase } from './buildTaskProvider';
 import { TaskPseudoTerminal } from './taskPseudoTerminal';
 import { androidHelper, iOSHelper, Helpers } from './helpers';
 import { PackageTaskProvider } from './packageTaskProvider';
-import { quickPick } from '../quickpicks';
-import { InteractionError } from '../commands';
 import { ExtensionContainer } from '../container';
-import { TitaniumTaskBase } from './commandTaskProvider';
+import { TitaniumTaskBase, TitaniumTaskDefinitionBase } from './commandTaskProvider';
 
 export type TitaniumTaskTypes = 'titanium-build' | 'titanium-package';
 
@@ -77,4 +75,35 @@ export async function getBuildTask(task: TitaniumTaskBase): Promise<vscode.Task>
 
 export async function getPackageTask(task: TitaniumTaskBase): Promise<vscode.Task> {
 	return packageTaskProvider.resolveTask(task);
+}
+
+/**
+ * Adds a task to the workspace tasks.json file.
+ *
+ * @param {TitaniumTaskDefinitionBase} task - Task definition to add.
+ * @param {string} folder - Workspace folder to add to.
+ * @returns {void}
+ */
+export async function addTask(task: TitaniumTaskDefinitionBase, folder: string): Promise<void> {
+	const workspaceTasks = vscode.workspace.getConfiguration('tasks', vscode.Uri.file(folder));
+	const allTasks = workspaceTasks && workspaceTasks.tasks as TitaniumTaskDefinitionBase[] || [];
+
+	allTasks.push(task);
+
+	await workspaceTasks.update('tasks', allTasks, vscode.ConfigurationTarget.WorkspaceFolder);
+}
+
+/**
+ * Gets the active tasks for the workspace, you should generally use `vscode.tasks.fetchTasks`
+ * but this is useful for when you need to fetch information that isn't available from that API
+ * such as the problem matchers associated with at ask
+ *
+ * @param {string} folder - Workspace folder to get tasks for.
+ * @returns {TitaniumTaskDefinitionBase[]}
+ */
+export function getTasks (folder: string): TitaniumTaskDefinitionBase[] {
+	const workspaceTasks = vscode.workspace.getConfiguration('tasks', vscode.Uri.file(folder));
+	const allTasks = workspaceTasks && workspaceTasks.tasks as TitaniumTaskDefinitionBase[] || [];
+
+	return allTasks;
 }

--- a/src/tasks/tasksHelper.ts
+++ b/src/tasks/tasksHelper.ts
@@ -13,6 +13,12 @@ export type TitaniumTaskTypes = 'titanium-build' | 'titanium-package';
 export type Platform = 'android' | 'ios';
 export type ProjectType = 'app' | 'module';
 
+export interface RunningTask {
+	buildOptions: AppBuildTaskTitaniumBuildBase;
+}
+
+export const runningTasks: Map<string, RunningTask> = new Map();
+
 const helpers: Helpers = {
 	android: androidHelper,
 	ios: iOSHelper
@@ -20,6 +26,7 @@ const helpers: Helpers = {
 
 const buildTaskProvider = new BuildTaskProvider(helpers);
 const packageTaskProvider = new PackageTaskProvider(helpers);
+
 export function registerTaskProviders (ctx: vscode.ExtensionContext): void {
 
 	ctx.subscriptions.push(
@@ -61,6 +68,7 @@ export interface TaskExecutionContext {
 	cancellationToken: vscode.CancellationToken;
 	folder: vscode.WorkspaceFolder;
 	terminal: TaskPseudoTerminal;
+	label: string;
 }
 
 export async function getBuildTask(task: TitaniumTaskBase): Promise<vscode.Task> {

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -1,4 +1,5 @@
-import { KeystoreInfo, LogLevel, Platform, WindowsCertInfo } from './common';
+import { KeystoreInfo, LogLevel, Platform as PlatformEnum, WindowsCertInfo } from './common';
+import { Platform } from '../tasks/tasksHelper';
 
 export interface BaseCLIOptions {
 	logLevel: LogLevel;
@@ -46,7 +47,7 @@ export interface BuildModuleOptions extends BaseBuildOptions {
 
 export interface BasePackageOptions extends BaseCLIOptions {
 	outputDirectory: string;
-	platform: Platform;
+	platform: PlatformEnum;
 	projectDir: string;
 	target: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ import appc from './appc';
 
 import { platform } from 'os';
 import { workspace } from 'vscode';
-import { AndroidPackageOptions, BuildAppOptions, BuildIosAppOptions, BuildModuleOptions, CleanAppOptions, CreateAppOptions, CreateModuleOptions, IosPackageOptions, PackageAppOptions, WindowsPackageOptions } from './types/cli';
+import { CleanAppOptions, CreateAppOptions, CreateModuleOptions } from './types/cli';
 import { IosCert, IosCertificateType, PlatformPretty } from './types/common';
 
 /**
@@ -281,106 +281,6 @@ function normalizeDriveLetter (filePath: string): string {
 
 function quoteArgument (arg: string): string {
 	return `"${arg}"`;
-}
-
-function isAppBuild (options: BuildAppOptions | BuildModuleOptions): options is BuildAppOptions {
-	return (options as BuildAppOptions).projectType === 'app';
-}
-
-export function buildArguments (options: BuildAppOptions | BuildModuleOptions): string[] {
-
-	const args = [
-		'run',
-		'--platform', options.platform,
-		'--log-level', options.logLevel,
-		'--project-dir', normalizeDriveLetter(options.projectDir)
-	];
-
-	if (options.buildOnly) {
-		args.push('--build-only');
-	}
-
-	if (isAppBuild(options)) {
-		args.push('--target', options.target!);
-
-		if (options.target !== 'ws-local') {
-			args.push('--device-id', options.deviceId!);
-		}
-
-		if (options.target === 'device' && options.platform === 'ios') {
-			args.push(
-				'--developer-name', (options as BuildIosAppOptions).iOSCertificate!,
-				'--pp-uuid', (options as BuildIosAppOptions).iOSProvisioningProfile!
-			);
-		}
-
-		if (options.liveview) {
-			args.push('--liveview');
-		}
-
-		if (options.debugPort && options.platform === 'android') {
-			args.push(
-				'--debug-host',
-				`/localhost:${options.debugPort}`
-			);
-		}
-
-		if (options.skipJsMinify) {
-			args.push('--skip-js-minify');
-		}
-
-		if (options.sourceMaps) {
-			args.push('--source-maps');
-		}
-
-		if (options.deployType) {
-			args.push(
-				'--deploy-type',
-				options.deployType
-			);
-		}
-	}
-
-	return args.map(arg => quoteArgument(arg));
-}
-
-export function packageArguments (options: PackageAppOptions): string[] {
-	const args = [
-		'run',
-		'--platform', options.platform,
-		'--target', options.target,
-		'--log-level', options.logLevel,
-		'--project-dir', normalizeDriveLetter(options.projectDir)
-	];
-
-	if (options.target !== 'dist-appstore') {
-		args.push('--output-dir', options.outputDirectory);
-	}
-
-	if (options.platform === 'android') {
-		args.push(
-			'--keystore', (options as AndroidPackageOptions).keystoreInfo.location,
-			'--alias', (options as AndroidPackageOptions).keystoreInfo.alias,
-			'--store-password', (options as AndroidPackageOptions).keystoreInfo.password
-		);
-		if ((options as AndroidPackageOptions).keystoreInfo.privateKeyPassword) {
-			args.push('--key-password', (options as AndroidPackageOptions).keystoreInfo.privateKeyPassword!);
-		}
-	} else if (options.platform === 'ios') {
-		args.push(
-			'--distribution-name', (options as IosPackageOptions).iOSCertificate!,
-			'--pp-uuid', (options as IosPackageOptions).iOSProvisioningProfile!
-		);
-	} else if (options.platform === 'windows') {
-		if ((options as WindowsPackageOptions).windowsCertInfo.location) {
-			args.push('--win-cert', (options as WindowsPackageOptions).windowsCertInfo.location!);
-		} else {
-			args.push('--win-cert');
-		}
-		args.push('--pfx-password', (options as WindowsPackageOptions).windowsCertInfo.password);
-		args.push('--win-publisher-id', (options as WindowsPackageOptions).windowsPublisherID!);
-	}
-	return args.map(arg => quoteArgument(arg));
 }
 
 export function createAppArguments (options: CreateAppOptions): string[] {


### PR DESCRIPTION
This PR changes the debugger to allow specifying a preLaunchTask in the configuration to build the application. If no preLaunchTask is specified we will create and add one to the tasks file.

Introduces a breaking change where we no longer support setting target and deviceId on the launch config, instead use a preLaunchTask to specify these.

Also cleans up some unused code, eslint warnings, and removes the debug activation into a `registerDebugProvider` function invoked in activates (we should continue to do this as we touch things imo)

JIRA: https://jira.appcelerator.org/browse/EDITOR-36