### PR TITLE
Remove windows platform from activity pane, bump minimum node version

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -20,4 +20,3 @@ You can learn more about User and Workspace settings in the [VS Code documentati
 | `titanium.general.useTerminalForBuild` | When true build/package commands will be run using the integrated terminal as opposed to using an output channel. | `true` |
 | `titanium.package.distributionOutputDirectory` | Output directory for package builds. | `dist` |
 | `titanium.project.defaultI18nLanguage` | Default language to use for i18n autocomplete. | `en` |
-| `titanium.windows.publisherID` | Publisher ID | `No Default` |

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "url": "git+https://github.com/appcelerator/vscode-appcelerator-titanium.git"
   },
   "engines": {
-    "vscode": "^1.41.0"
+    "vscode": "^1.41.0",
+    "node": ">=12.4.0"
   },
   "activationEvents": [
     "onDebug",
@@ -451,11 +452,6 @@
           "type": "string",
           "default": "en",
           "description": "Default language to use for i18n autocomplete."
-        },
-        "titanium.windows.publisherID": {
-          "type": "string",
-          "description": "Publisher ID",
-          "default": null
         }
       }
     },

--- a/src/appc.ts
+++ b/src/appc.ts
@@ -7,7 +7,7 @@ import { homedir } from 'os';
 import { window } from 'vscode';
 import { ExtensionContainer } from './container';
 import { IosCert, IosCertificateType, ProvisioningProfile } from './types/common';
-import { AndroidEmulator, AppcInfo, IosDevice, IosSimulator, WindowsEmulator, TitaniumSDK, AndroidDevice, WindowsDevice } from './types/environment-info';
+import { AndroidEmulator, AppcInfo, IosDevice, IosSimulator, TitaniumSDK, AndroidDevice } from './types/environment-info';
 import { iOSProvisioningProfileMatchesAppId } from './utils';
 
 export interface AlloyGenerateOptions {
@@ -244,42 +244,6 @@ export class Appc {
 		return {
 			devices: this.androidDevices(),
 			emulators: this.androidEmulators()
-		};
-	}
-
-	/**
-	 * Windows devices
-	 *
-	 * @returns {Array}
-	 */
-	public windowsDevices (): WindowsDevice[] {
-		if (this.info.windows && this.info.windows.devices) {
-			return this.info.windows.devices;
-		}
-		return [];
-	}
-
-	/**
-	 * Windows emulators
-	 *
-	 * @returns {Object}
-	 */
-	public windowsEmulators (): { [key: string]: WindowsEmulator[] } {
-		if (this.info.windows && this.info.windows.emulators) {
-			return this.info.windows.emulators;
-		}
-		return {};
-	}
-
-	/**
-	 * Windows targets
-	 *
-	 * @returns {Object}
-	 */
-	public windowsTargets (): { devices: WindowsDevice[]; emulators:  { [key: string]: WindowsEmulator[] } } {
-		return {
-			devices: this.windowsDevices(),
-			emulators: this.windowsEmulators()
 		};
 	}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,7 +23,5 @@ export enum WorkspaceState {
 	LastKeystorePath = 'lastKeystorePath',
 	LastCreationPath = 'lastCreationPath',
 	LastAndroidDebug = 'lastAndroidDebugOptions',
-	LastiOSDebug = 'lastiOSDebugOptions',
-	LastPublisherID = 'lastWindowsPublisherID',
-	LastWindowsCertPath = 'lastWindowsCertPath'
+	LastiOSDebug = 'lastiOSDebugOptions'
 }

--- a/src/explorer/nodes/osVerNode.ts
+++ b/src/explorer/nodes/osVerNode.ts
@@ -20,7 +20,7 @@ export class OSVerNode extends BaseNode {
 	) {
 		super(label);
 		this.version = label;
-		this.targetId = targetForName(this.target, this.platform);
+		this.targetId = targetForName(this.target);
 	}
 
 	public getChildren (): DeviceNode[] {
@@ -29,14 +29,6 @@ export class OSVerNode extends BaseNode {
 			const sims = appc.iOSSimulators();
 			for (const sim of sims[this.version]) {
 				simulators.push(new DeviceNode(sim.name, this.platform, this.target, sim.udid, this.targetId, this.version));
-			}
-		} else if (this.platform === 'windows') {
-			for (const emulator of appc.windowsEmulators()['10.0']) {
-				if (emulator.uapVersion !== this.version) {
-					continue;
-				}
-				const label = emulator.name.replace('Mobile Emulator ', '');
-				simulators.push(new DeviceNode(label, this.platform, 'wp-emulator', emulator.udid, this.targetId));
 			}
 		}
 		return simulators;

--- a/src/explorer/nodes/platformNode.ts
+++ b/src/explorer/nodes/platformNode.ts
@@ -31,11 +31,6 @@ export class PlatformNode extends BaseNode {
 					new TargetNode('Device', this.platform),
 					new TargetNode('Simulator', this.platform)
 				];
-			case 'windows':
-				return [
-					new TargetNode('Device', this.platform),
-					new TargetNode('Emulator', this.platform)
-				];
 			default:
 				return [];
 		}

--- a/src/explorer/nodes/targetNode.ts
+++ b/src/explorer/nodes/targetNode.ts
@@ -3,7 +3,6 @@ import { BaseNode } from './baseNode';
 import { DeviceNode } from './deviceNode';
 import { OSVerNode } from './osVerNode';
 
-import * as semver from 'semver';
 import appc from '../../appc';
 import { Platform } from '../../types/common';
 import { targetForName } from '../../utils';
@@ -19,7 +18,7 @@ export class TargetNode extends BaseNode {
 		public readonly platform: Platform
 	) {
 		super(label);
-		this.targetId = targetForName(this.label, this.platform);
+		this.targetId = targetForName(this.label);
 	}
 
 	public getChildren (): Array<OSVerNode|DeviceNode> {
@@ -57,28 +56,6 @@ export class TargetNode extends BaseNode {
 							}
 							devices.push(new DeviceNode(label, this.platform, this.label, emulator.id, this.targetId));
 						}
-					}
-					break;
-			}
-		} else if (this.platform === 'windows') {
-			switch (this.label) {
-				case 'Device':
-					for (const device of appc.windowsDevices()) {
-						devices.push(new DeviceNode(device.name, this.platform, this.label, device.udid, this.targetId));
-					}
-					devices.push(new DeviceNode('Local Machine', this.platform, 'ws-local', 'ws-local', 'ws-local'));
-					break;
-				case 'Emulator':
-					const emulatorVersions: Set<string> = new Set();
-					for (const emulator of appc.windowsEmulators()['10.0']) {
-						emulatorVersions.add(emulator.uapVersion);
-					}
-					// Sort into descending value
-					const orderedVersions = Array.from(emulatorVersions).sort((a, b) => {
-						return semver.compare(semver.coerce(a)!, semver.coerce(b)!);
-					}).reverse();
-					for (const version of orderedVersions) {
-						devices.push(new OSVerNode(version, Platform.windows, 'wp-emulator'));
 					}
 					break;
 			}

--- a/src/project.ts
+++ b/src/project.ts
@@ -234,7 +234,6 @@ export class Project {
 			path.join(rootPath, 'android'),
 			path.join(rootPath, 'ios'),
 			path.join(rootPath, 'iphone'),
-			path.join(rootPath, 'windows'),
 		];
 		for (let i = 0, numPaths = paths.length; i < numPaths; i++) {
 			this.loadModuleAt(paths[i]);

--- a/src/quickpicks/common.ts
+++ b/src/quickpicks/common.ts
@@ -248,16 +248,6 @@ export async function selectiOSSimulator (iOSVersion?: string): Promise<CustomQu
 	return quickPick(simulators, { placeHolder: 'Select simulator' }) as Promise<CustomQuickPick & { udid: string }>;
 }
 
-export function selectWindowsDevice (): Promise<CustomQuickPick> {
-	const devices = appc.windowsDevices().map(({ name, udid }) => ({ id: udid, label: name, udid }));
-	return quickPick(devices, { placeHolder: 'Select device' });
-}
-
-export function selectWindowsEmulator (): Promise<CustomQuickPick> {
-	const emulators = appc.windowsEmulators()['10.0'].map(({ name, udid }) => ({ id: udid, label: name, udid }));
-	return quickPick(emulators, { placeHolder: 'Select emulator' });
-}
-
 export async function selectUpdates (updates: UpdateInfo[]): Promise<UpdateChoice[]> {
 	const choices: UpdateChoice[] = updates
 		.map(update => ({
@@ -299,60 +289,4 @@ export async function selectDevice (platform: string, target: string): Promise<C
 	} else {
 		throw new Error(`Unsupported platform and combination target ${platform} + ${target}`);
 	}
-}
-
-export async function selectWindowsCertificate (lastUsed?: string, savedCertPath?: string): Promise<string|undefined> {
-	const items = [
-		{
-			label: 'Browse for certificate',
-			id: 'browse'
-		},
-		{
-			label: 'Create certificate',
-			id: 'create'
-		}
-	];
-	if (lastUsed) {
-		items.push({
-			label: `Last used ${lastUsed}`,
-			id: 'last'
-		});
-	}
-	if (savedCertPath) {
-		items.push({
-			label: `Saved ${savedCertPath}`,
-			id: 'saved'
-		});
-	}
-	const certificateAction = await quickPick(items, { placeHolder: 'Browse for certificate or use last certificate' });
-	if (certificateAction.id === 'browse') {
-		const uri = await window.showOpenDialog({ canSelectFolders: false, canSelectMany: false });
-		if (!uri) {
-			throw new UserCancellation();
-		}
-		return uri[0].path;
-	} else if (certificateAction.id === 'create') {
-		return undefined;
-	} else if (savedCertPath && certificateAction.id === 'saved') {
-		if (!path.isAbsolute(savedCertPath)) {
-			savedCertPath = path.resolve(workspace.rootPath!, savedCertPath);
-		}
-		return savedCertPath;
-	} else if (certificateAction.id === 'last' && lastUsed) {
-		return lastUsed;
-	}
-}
-
-export async function enterWindowsSigningInfo (lastUsed?: string, savedCertPath?: string): Promise<{ location: string|undefined; password: string }> {
-	const location = await selectWindowsCertificate(lastUsed, savedCertPath);
-
-	if (location && !await pathExists(location)) {
-		throw new InteractionError(`The certificate file ${location} does not exist`);
-	}
-	const password = await enterPassword({ placeHolder: 'Enter the certificate password' });
-
-	return {
-		location,
-		password
-	};
 }

--- a/src/test/suite/fixtures/data/ti_info.ts
+++ b/src/test/suite/fixtures/data/ti_info.ts
@@ -4913,11 +4913,5 @@ export default
 			crashDir: '/Users/user/Library/Logs/DiagnosticReports'
 		},
 		tisdk: '6.1.2.GA'
-	},
-	windows: {
-		devices: [],
-		emulators: {
-
-		}
 	}
 };

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -1,4 +1,4 @@
-import { KeystoreInfo, LogLevel, Platform as PlatformEnum, WindowsCertInfo } from './common';
+import { KeystoreInfo, LogLevel, Platform as PlatformEnum,  } from './common';
 import { Platform } from '../tasks/tasksHelper';
 
 export interface BaseCLIOptions {
@@ -34,12 +34,7 @@ export interface BuildIosAppOptions extends BuildAppBase {
 	iOSProvisioningProfile?: string;
 }
 
-export interface BuildWindowsAppOptions extends BuildAppBase {
-	windowsCertInfo?: WindowsCertInfo;
-	windowsPublisherID?: string;
-}
-
-export type BuildAppOptions = BuildAndroidAppOptions | BuildIosAppOptions | BuildWindowsAppOptions;
+export type BuildAppOptions = BuildAndroidAppOptions | BuildIosAppOptions;
 
 export interface BuildModuleOptions extends BaseBuildOptions {
 	outputDirectory?: string;
@@ -61,12 +56,7 @@ export interface IosPackageOptions extends BasePackageOptions {
 	iOSProvisioningProfile: string;
 }
 
-export interface WindowsPackageOptions extends BasePackageOptions {
-	windowsCertInfo: WindowsCertInfo;
-	windowsPublisherID?: string;
-}
-
-export type PackageAppOptions = AndroidPackageOptions | IosPackageOptions | WindowsPackageOptions;
+export type PackageAppOptions = AndroidPackageOptions | IosPackageOptions;
 
 export interface CreateOptions extends BaseCLIOptions {
 	id: string;

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -1,4 +1,4 @@
-import { KeystoreInfo, LogLevel, Platform as PlatformEnum,  } from './common';
+import { KeystoreInfo, LogLevel, Platform as PlatformEnum  } from './common';
 import { Platform } from '../tasks/tasksHelper';
 
 export interface BaseCLIOptions {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -33,11 +33,6 @@ export interface ProvisioningProfile {
 	uuid: string;
 }
 
-export interface WindowsCertInfo {
-	location: string|undefined;
-	password: string;
-}
-
 export enum LogLevel {
 	Debug = 'debug',
 	Error = 'error',
@@ -53,14 +48,12 @@ export enum IosCertificateType {
 
 export enum PlatformPretty {
 	android = 'Android',
-	ios = 'iOS',
-	windows = 'Windows'
+	ios = 'iOS'
 }
 
 export enum Platform {
 	android = 'android',
-	ios = 'ios',
-	windows = 'windows'
+	ios = 'ios'
 }
 
 export interface UpdateChoice extends Omit<UpdateInfo, 'hasUpdate' | 'releaseNotes'> {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -27,8 +27,4 @@ export interface Config {
 	project: {
 		defaultI18nLanguage: string;
 	};
-	windows: {
-		signingCertPath: string;
-		publisherID: string;
-	};
 }

--- a/src/types/environment-info.ts
+++ b/src/types/environment-info.ts
@@ -41,17 +41,6 @@ export interface TitaniumSDK {
 	fullversion?: string;
 }
 
-export interface WindowsEmulator {
-	udid: string;
-	name: string;
-	uapVersion: string;
-}
-
-export interface WindowsDevice {
-	udid: string;
-	name: string;
-}
-
 export interface AppcInfo {
 	android: {
 		devices: AndroidDevice[];
@@ -90,11 +79,5 @@ export interface AppcInfo {
 	titaniumCLI: {
 		version: string;
 		selectedSDK: string;
-	};
-	windows: {
-		devices: WindowsDevice[];
-		emulators: {
-			[key: string]: WindowsEmulator[];
-		};
 	};
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ export function platforms (): string[] {
 		case 'darwin':
 			return [ 'ios', 'android' ];
 		case 'win32':
-			return [ 'android', 'windows' ];
+			return [ 'android' ];
 		case 'linux':
 			return [ 'android' ];
 		default:
@@ -64,8 +64,6 @@ export function nameForPlatform (targetPlatform: string): PlatformPretty|undefin
 			return PlatformPretty.android;
 		case 'ios':
 			return PlatformPretty.ios;
-		case 'windows':
-			return PlatformPretty.windows;
 	}
 }
 
@@ -98,7 +96,7 @@ export function nameForTarget (target: string): string {
  * @param {String} targetPlatform - platform to get target for.
  * @returns {String}
  */
-export function targetForName (name: string, targetPlatform: string): string {
+export function targetForName (name: string): string {
 	name = name.toLowerCase();
 	switch (name) {
 		case 'Ad-Hoc':
@@ -108,9 +106,7 @@ export function targetForName (name: string, targetPlatform: string): string {
 		case 'Play Store':
 			return 'dist-playstore';
 		case 'device':
-			return targetPlatform === 'windows' ? 'wp-device' : name;
 		case 'emulator':
-			return targetPlatform === 'windows' ? 'wp-emulator' : name;
 		case 'simulator':
 		default:
 			return name;
@@ -124,8 +120,6 @@ export function targetsForPlatform (platformName: string): string[] {
 			return [ 'emulator', 'device', 'dist-playstore' ];
 		case 'ios':
 			return [ 'simulator', 'device', 'dist-adhoc', 'dist-appstore' ];
-		case 'windows':
-			return [ 'dist-phonestore', 'dist-winstore', 'wp-emulator', 'wp-device', 'ws-local' ];
 		default:
 			return [];
 	}


### PR DESCRIPTION
* We didn't add support to tasks for building Windows applications, so keeping the activity pane information around didn't make much sense as it did nothing - [EDITOR-35](https://jira.appcelerator.org/browse/EDITOR-35)
* Bump the min node version to 12.4.0 in accordance with our min VSCode version