### PR TITLE
Pre launch task refactor

### DIFF
--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -37,7 +37,15 @@ This will automatically generate two debug configurations in `.vscode/launch.jso
 
 The `preLaunchTask` property allows setting a task from the `.vscode/tasks.json` file to be used to build the application. This allows you to declare the target and device ID for your build so you won't be prompted for these every build. For documentation on configuring tasks see the [tasks documentation](./tasks.md).
 
-If no `preLaunchTask` is specified, then a default task is created and added to the `.vscode/tasks.json` file for you which is then reused when debugging in future. When using these tasks you will be prompted for the target and device ID every build.
+If no `preLaunchTask` is specified, then the default Titanium Debug task will be used. This task will prompt for the target and device ID every build.
+
+When creating a `preLaunchTask` for debugging a Titanium application, the following properties are required to be set on the task:
+
+* `isBackground` must be set to `true`
+* `problemMatcher` must include `"$ti-app-launch"`
+* `titaniumBuild.debug` must be set to `true`
+
+These properties will be enforced at the start of the debug session and the debug session will error out if they are not set.
 
 ## Debugging an application
 

--- a/src/debugger/titaniumDebugHelper.ts
+++ b/src/debugger/titaniumDebugHelper.ts
@@ -20,7 +20,12 @@ async function handleCustomEvent(event: vscode.DebugSessionCustomEvent): Promise
 				}
 			};
 
-			const runningTask = runningTasks.get(providedArgs.preLaunchTask);
+			// When using a provided task for debugging the name will be prefixed
+			// with "Titanium:" internally by vscode, but it's not available to us
+			// on the label, so we need remove that to lookup the task
+			const taskLabel = providedArgs.preLaunchTask.replace('Titanium:', '').trim();
+
+			const runningTask = runningTasks.get(taskLabel);
 
 			if (!runningTask) {
 				response.result.isError = true;

--- a/src/tasks/helpers/android.ts
+++ b/src/tasks/helpers/android.ts
@@ -15,7 +15,6 @@ export interface AndroidBuildTaskDefinition extends BuildTaskDefinitionBase {
 export interface AndroidBuildTaskTitaniumBuildBase extends AppBuildTaskTitaniumBuildBase {
 	platform: 'android';
 	target: 'device' | 'emulator';
-	debugPort?: number;
 }
 
 export interface AndroidTitanumPackageDefiniton extends PackageTaskDefinitionBase {
@@ -62,8 +61,8 @@ export class AndroidHelper extends TaskHelper {
 
 		builder.addOption('--device-id', definition.deviceId);
 
-		if (definition.debugPort) {
-			builder.addOption('--debug-host', `/localhost:${definition.debugPort}`);
+		if (definition.debugPort || definition.debug) {
+			builder.addOption('--debug-host', `/localhost:${definition.debugPort || '9000'}`);
 		}
 
 		this.storeLastState(WorkspaceState.LastBuildState, definition);

--- a/src/tasks/helpers/base.ts
+++ b/src/tasks/helpers/base.ts
@@ -26,7 +26,7 @@ function isAppBuild<T extends PackageTaskTitaniumBuildBase>(definition: PackageT
 	return false;
 }
 
-function shouldEnableLiveview (definition: AppBuildTaskTitaniumBuildBase, context: TaskExecutionContext): boolean {
+function shouldEnableLiveview (definition: AppBuildTaskTitaniumBuildBase): boolean {
 	const globalSetting = ExtensionContainer.config.build.liveview;
 
 	if (!definition.debug && (definition.liveview === true || globalSetting)) {
@@ -62,7 +62,7 @@ export abstract class TaskHelper {
 
 		if (!isDistributionBuild(definition)) {
 
-			if (shouldEnableLiveview(definition, context)) {
+			if (shouldEnableLiveview(definition)) {
 				builder.addFlag('--liveview');
 			}
 

--- a/src/tasks/helpers/base.ts
+++ b/src/tasks/helpers/base.ts
@@ -26,6 +26,15 @@ function isAppBuild<T extends PackageTaskTitaniumBuildBase>(definition: PackageT
 	return false;
 }
 
+function shouldEnableLiveview (definition: AppBuildTaskTitaniumBuildBase, context: TaskExecutionContext): boolean {
+	const globalSetting = ExtensionContainer.config.build.liveview;
+
+	if (!definition.debug && (definition.liveview === true || globalSetting)) {
+		return true;
+	}
+	return false;
+}
+
 export abstract class TaskHelper {
 
 	public abstract async resolveAppBuildCommandLine (context: TaskExecutionContext, definition: BuildTaskTitaniumBuildBase): Promise<string>
@@ -53,7 +62,7 @@ export abstract class TaskHelper {
 
 		if (!isDistributionBuild(definition)) {
 
-			if (definition.liveview) {
+			if (shouldEnableLiveview(definition, context)) {
 				builder.addFlag('--liveview');
 			}
 

--- a/src/tasks/taskPseudoTerminal.ts
+++ b/src/tasks/taskPseudoTerminal.ts
@@ -144,4 +144,11 @@ export class TaskPseudoTerminal implements vscode.Pseudoterminal {
 		message = message.replace(/\r?\n/g, '\r\n');
 		this.writeEmitter.fire(`\x1b[${color}${message}\x1b[0m`);
 	}
+
+	public handleInput(data: string): void {
+		// Char code 3 is ctrl+c, so kill the task
+		if (data === String.fromCharCode(3)) {
+			this.close();
+		}
+	}
 }

--- a/src/tasks/taskPseudoTerminal.ts
+++ b/src/tasks/taskPseudoTerminal.ts
@@ -91,7 +91,8 @@ export class TaskPseudoTerminal implements vscode.Pseudoterminal {
 			cancellationToken: this.cts.token,
 			folder,
 			terminal: this,
-			label: this.task.name
+			label: this.task.name,
+			task: this.task
 		};
 
 		ExtensionContainer.context.globalState.update(GlobalState.Running, true);

--- a/src/tasks/tasksHelper.ts
+++ b/src/tasks/tasksHelper.ts
@@ -67,6 +67,7 @@ export interface TaskExecutionContext {
 	folder: vscode.WorkspaceFolder;
 	terminal: TaskPseudoTerminal;
 	label: string;
+	task: TitaniumTaskBase;
 }
 
 export async function getBuildTask(task: TitaniumTaskBase): Promise<vscode.Task> {
@@ -75,22 +76,6 @@ export async function getBuildTask(task: TitaniumTaskBase): Promise<vscode.Task>
 
 export async function getPackageTask(task: TitaniumTaskBase): Promise<vscode.Task> {
 	return packageTaskProvider.resolveTask(task);
-}
-
-/**
- * Adds a task to the workspace tasks.json file.
- *
- * @param {TitaniumTaskDefinitionBase} task - Task definition to add.
- * @param {string} folder - Workspace folder to add to.
- * @returns {void}
- */
-export async function addTask(task: TitaniumTaskDefinitionBase, folder: string): Promise<void> {
-	const workspaceTasks = vscode.workspace.getConfiguration('tasks', vscode.Uri.file(folder));
-	const allTasks = workspaceTasks && workspaceTasks.tasks as TitaniumTaskDefinitionBase[] || [];
-
-	allTasks.push(task);
-
-	await workspaceTasks.update('tasks', allTasks, vscode.ConfigurationTarget.WorkspaceFolder);
 }
 
 /**


### PR DESCRIPTION
* Add `provideTasks` to the `BuildTaskProvider` and use those tasks as the default `preLaunchTask` so we don't need to add tasks into a users project just t o debug.
* [EDITOR-46](https://jira.appcelerator.org/browse/EDITOR-46) - Always make sure we set `--debug-host` when debugging on Android
* [EDITOR-43](https://jira.appcelerator.org/browse/EDITOR-43) - Make sure we respect the global liveview setting when using a task
* [EDITOR-47](https://jira.appcelerator.org/browse/EDITOR-47) - Allow killing a task using `CTRL+C`