### PR TITLE
refactor: add option to rerun build and package commands on error

### DIFF
--- a/src/commands/buildApp.ts
+++ b/src/commands/buildApp.ts
@@ -96,7 +96,16 @@ export async function buildApplication (node: DeviceNode | OSVerNode | PlatformN
 		await vscode.tasks.executeTask(task);
 	} catch (error) {
 		if (error instanceof InteractionError) {
-			await handleInteractionError(error);
+			await handleInteractionError(error)
+				.then(async function () {
+					const choice = await vscode.window.showErrorMessage('Build App failed', { title: 'Rerun' });
+					if (!choice) {
+						return;
+					}
+					if (choice.title === 'Rerun') {
+						buildApplication(node);
+					}
+				});
 		}
 	}
 }

--- a/src/commands/buildModule.ts
+++ b/src/commands/buildModule.ts
@@ -34,7 +34,16 @@ export async function buildModule (node: DeviceNode | OSVerNode | PlatformNode |
 		await vscode.tasks.executeTask(task);
 	} catch (error) {
 		if (error instanceof InteractionError) {
-			await handleInteractionError(error);
+			await handleInteractionError(error)
+				.then(async function () {
+					const choice = await vscode.window.showErrorMessage('Build Module failed.', { title: 'Rerun' });
+					if (!choice) {
+						return;
+					}
+					if (choice.title === 'Rerun') {
+						buildModule(node);
+					}
+				});
 		}
 	}
 }

--- a/src/commands/packageApp.ts
+++ b/src/commands/packageApp.ts
@@ -56,7 +56,16 @@ export async function packageApplication (node: DeviceNode | OSVerNode | Platfor
 		await vscode.tasks.executeTask(task);
 	} catch (error) {
 		if (error instanceof InteractionError) {
-			await handleInteractionError(error);
+			await handleInteractionError(error)
+				.then(async function () {
+					const choice = await vscode.window.showErrorMessage('Package App failed', { title: 'Rerun' });
+					if (!choice) {
+						return;
+					}
+					if (choice.title === 'Rerun') {
+						packageApplication(node);
+					}
+				});
 		}
 	}
 }

--- a/src/commands/packageModule.ts
+++ b/src/commands/packageModule.ts
@@ -35,7 +35,16 @@ export async function packageModule (node: DeviceNode | OSVerNode | PlatformNode
 		await vscode.tasks.executeTask(task);
 	} catch (error) {
 		if (error instanceof InteractionError) {
-			await handleInteractionError(error);
+			await handleInteractionError(error)
+				.then(async function () {
+					const choice = await vscode.window.showErrorMessage('Package Module failed', { title: 'Rerun' });
+					if (!choice) {
+						return;
+					}
+					if (choice.title === 'Rerun') {
+						packageModule(node);
+					}
+				});
 		}
 	}
 }


### PR DESCRIPTION
Add rerun notification when the build fails, for example, an invalid session. Added the rerun option for build app, build module, package app and package module.

https://jira.appcelerator.org/browse/EDITOR-38