### PR TITLE
refactor: reduce number of lint warnings

### DIFF
--- a/src/commands/buildApp.ts
+++ b/src/commands/buildApp.ts
@@ -34,18 +34,23 @@ function getDeviceNameFromId (deviceID: string, platform: Platform, target: stri
 	return deviceName;
 }
 
+interface LastBuildState extends AppBuildTaskTitaniumBuildBase {
+	deviceId: string;
+	target: 'device' | 'emulator' | 'simulator';
+}
+
 export async function buildApplication (node: DeviceNode | OSVerNode | PlatformNode | TargetNode): Promise<void> {
 	try {
 		checkLogin();
 
-		const lastBuildState = ExtensionContainer.context.workspaceState.get<AppBuildTaskTitaniumBuildBase>(WorkspaceState.LastBuildState);
+		const lastBuildState = ExtensionContainer.context.workspaceState.get<LastBuildState>(WorkspaceState.LastBuildState);
 		let lastBuildDescription: string|undefined;
 
 		if (lastBuildState) {
 			try {
 				// TODO: map the device ID back based off the info output, this also allows us to ignore invalid build states for example by a device being disconnected
-				const deviceName = getDeviceNameFromId(lastBuildState.deviceId!, lastBuildState.platform, lastBuildState.target!);
-				lastBuildDescription = `${nameForPlatform(lastBuildState.platform)} ${nameForTarget(lastBuildState.target!)} ${deviceName}`;
+				const deviceName = getDeviceNameFromId(lastBuildState.deviceId, lastBuildState.platform, lastBuildState.target);
+				lastBuildDescription = `${nameForPlatform(lastBuildState.platform)} ${nameForTarget(lastBuildState.target)} ${deviceName}`;
 			} catch (error) {
 				console.log(error);
 				// Ignore and clear the state, we don't want to error due to a bad state

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -70,7 +70,7 @@ export function checkLogin (): void {
 }
 
 export async function handleInteractionError (error: InteractionError): Promise<void> {
-	const actionToTake: any = await window.showErrorMessage(error.message, error.messageOptions, ...error.interactionChoices);
+	const actionToTake = await window.showErrorMessage(error.message, error.messageOptions, ...error.interactionChoices);
 	if (actionToTake) {
 		actionToTake.run();
 	}

--- a/src/commands/createApp.ts
+++ b/src/commands/createApp.ts
@@ -28,8 +28,8 @@ export async function createApplication (): Promise<void> {
 		const platforms = await selectPlatforms();
 		const enableServices = await yesNoQuestion({ placeHolder: 'Enable services?' });
 		const workspaceDir = await selectCreationLocation(lastCreationPath);
-		ExtensionContainer.context.workspaceState.update(WorkspaceState.LastCreationPath, workspaceDir!.fsPath);
-		if (await fs.pathExists(path.join(workspaceDir!.fsPath, name))) {
+		ExtensionContainer.context.workspaceState.update(WorkspaceState.LastCreationPath, workspaceDir.fsPath);
+		if (await fs.pathExists(path.join(workspaceDir.fsPath, name))) {
 			force = await yesNoQuestion({ placeHolder: 'That app already exists. Would you like to overwrite?' }, true);
 		}
 
@@ -40,13 +40,13 @@ export async function createApplication (): Promise<void> {
 			logLevel,
 			name,
 			platforms,
-			workspaceDir: workspaceDir!.fsPath,
+			workspaceDir: workspaceDir.fsPath,
 		});
 		await ExtensionContainer.terminal.runCommandInBackground(args, { cancellable: false, location: ProgressLocation.Notification, title: 'Creating application' });
 		// TODO: Once workspace support is figured out, add an "add to workspace command"
 		const dialog = await window.showInformationMessage('Project created. Would you like to open it?', { modal: true }, { title: 'Open Project' });
 		if (dialog) {
-			const projectDir = Uri.file(path.join(workspaceDir!.fsPath, name));
+			const projectDir = Uri.file(path.join(workspaceDir.fsPath, name));
 			await commands.executeCommand(VSCodeCommands.OpenFolder, projectDir, true);
 		}
 	} catch (error) {

--- a/src/commands/createModule.ts
+++ b/src/commands/createModule.ts
@@ -27,8 +27,8 @@ export async function createModule (): Promise<void> {
 		});
 		const platforms = await selectPlatforms();
 		const workspaceDir = await selectCreationLocation(lastCreationPath);
-		ExtensionContainer.context.workspaceState.update(WorkspaceState.LastCreationPath, workspaceDir!.fsPath);
-		if (await fs.pathExists(path.join(workspaceDir!.fsPath, name))) {
+		ExtensionContainer.context.workspaceState.update(WorkspaceState.LastCreationPath, workspaceDir.fsPath);
+		if (await fs.pathExists(path.join(workspaceDir.fsPath, name))) {
 			force = await yesNoQuestion({ placeHolder: 'That module already exists. Would you like to overwrite?' }, true);
 		}
 
@@ -38,13 +38,13 @@ export async function createModule (): Promise<void> {
 			logLevel,
 			name,
 			platforms,
-			workspaceDir: workspaceDir!.fsPath,
+			workspaceDir: workspaceDir.fsPath,
 		});
 		await ExtensionContainer.terminal.runCommandInBackground(args, { cancellable: false, location: ProgressLocation.Notification, title: 'Creating module' });
 		// TODO: Once workspace support is figured out, add an "add to workspace command"
 		const dialog = await window.showInformationMessage('Project created. Would you like to open it?', { modal: true }, { title: 'Open Project' });
 		if (dialog) {
-			const projectDir = Uri.file(path.join(workspaceDir!.fsPath, name));
+			const projectDir = Uri.file(path.join(workspaceDir.fsPath, name));
 			await commands.executeCommand(VSCodeCommands.OpenFolder, projectDir, true);
 		}
 	} catch (error) {

--- a/src/commands/packageApp.ts
+++ b/src/commands/packageApp.ts
@@ -9,16 +9,20 @@ import { WorkspaceState } from '../constants';
 import { nameForPlatform, nameForTarget } from '../utils';
 import { PackageTask, AppPackageTaskTitaniumBuildBase } from '../tasks/packageTaskProvider';
 
+interface LastState extends AppPackageTaskTitaniumBuildBase {
+	target: 'dist-appstore' | 'dist-adhoc' | 'dist-playstore';
+}
+
 export async function packageApplication (node: DeviceNode | OSVerNode | PlatformNode | TargetNode): Promise<void> {
 	try {
 		checkLogin();
 
-		const lastState = ExtensionContainer.context.workspaceState.get<AppPackageTaskTitaniumBuildBase>(WorkspaceState.LastPackageState);
+		const lastState = ExtensionContainer.context.workspaceState.get<LastState>(WorkspaceState.LastPackageState);
 		let lastDescription: string|undefined;
 
 		if (lastState) {
 			try {
-				lastDescription = `${nameForPlatform(lastState.platform)} ${nameForTarget(lastState.target!)}`;
+				lastDescription = `${nameForPlatform(lastState.platform)} ${nameForTarget(lastState.target)}`;
 			} catch (error) {
 				console.log(error);
 				// Ignore and clear the state, we don't want to error due to a bad state

--- a/src/common/extensionProtocol.ts
+++ b/src/common/extensionProtocol.ts
@@ -1,6 +1,7 @@
 import { IAttachRequestArgs, ILaunchRequestArgs } from '@awam/vscode-chrome-debug-core';
 import { LogLevel } from '../types/common';
 import { Platform } from '../tasks/tasksHelper';
+import { AppBuildTaskTitaniumBuildBase } from '../tasks/buildTaskProvider';
 
 export interface Request {
 	id: string;
@@ -10,7 +11,11 @@ export interface Request {
 
 export interface Response {
 	id: string;
-	result: any;
+	result: {
+		isError: boolean;
+		message?: string;
+		buildInfo?: AppBuildTaskTitaniumBuildBase;
+	};
 }
 
 export interface FeedbackOptions {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as xml2js from 'xml2js';
 
-export async function determineProjectType (projectDirectory: string) {
+export async function determineProjectType (projectDirectory: string): Promise<'alloy' | 'classic'> {
 	if (await fs.pathExists(path.join(projectDirectory, 'app'))) {
 		return 'alloy';
 	} else {

--- a/src/debugger/titaniumDebugConfigurationProvider.ts
+++ b/src/debugger/titaniumDebugConfigurationProvider.ts
@@ -21,7 +21,7 @@ function validateTask (task: AppBuildTaskDefinitionBase, ourConfig: vscode.Debug
 
 export class TitaniumDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 
-	public async resolveDebugConfiguration (folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration> {
+	public async resolveDebugConfiguration (folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration): Promise<vscode.DebugConfiguration> {
 		if (!config.projectDir) {
 			config.projectDir = '${workspaceFolder}'; // eslint-disable-line no-template-curly-in-string
 		}
@@ -86,14 +86,12 @@ export class TitaniumDebugConfigurationProvider implements vscode.DebugConfigura
 			try {
 				await which('ios_webkit_debug_proxy');
 			} catch (error) {
-				vscode.window.showErrorMessage('Unable to find ios-webkit-debug-proxy. Please ensure it is installed', {
+				const action = await vscode.window.showErrorMessage('Unable to find ios-webkit-debug-proxy. Please ensure it is installed', {
 					title: 'Open docs'
-				}).then(action => {
-					if (action) {
-						vscode.env.openExternal(vscode.Uri.parse('https://github.com/appcelerator/vscode-appcelerator-titanium/blob/master/doc/debugging.md'));
-					}
-					return;
 				});
+				if (action) {
+					vscode.env.openExternal(vscode.Uri.parse('https://github.com/appcelerator/vscode-appcelerator-titanium/blob/master/doc/debugging.md'));
+				}
 				throw new Error('Unable to start debugger as ios_webkit_debug_proxy is not installed.');
 			}
 		}

--- a/src/debugger/titaniumPathTransformer.ts
+++ b/src/debugger/titaniumPathTransformer.ts
@@ -95,7 +95,7 @@ export class TitaniumPathTransformer extends BasePathTransformer {
 
 		if (this.projectType === 'alloy') {
 			searchFolders.push(path.join(appRoot, 'lib'));
-			searchFolders.push(path.join(appRoot, 'controllers', this.platform!));
+			searchFolders.push(path.join(appRoot, 'controllers', this.platform));
 		}
 
 		for (const folder of searchFolders) {

--- a/src/debugger/titaniumTargetDiscovery.ts
+++ b/src/debugger/titaniumTargetDiscovery.ts
@@ -5,7 +5,7 @@ export class TitaniumTargetDiscovery extends chromeTargetDiscoveryStrategy.Chrom
 	constructor () {
 		super(logger, new telemetry.TelemetryReporter());
 	}
-	public getTarget (address: string, port: number, targetFilter?: chromeConnection.ITargetFilter, targetUrl?: string): Promise<chromeConnection.ITarget> {
+	public getTarget (address: string, port: number): Promise<chromeConnection.ITarget> {
 		return Promise.resolve({
 			description: 'Titanium Debug Target',
 			devtoolsFrontendUrl: `chrome-devtools://devtools/bundled/inspector.html?experiments=true&ws=${address}:${port}`,
@@ -17,7 +17,7 @@ export class TitaniumTargetDiscovery extends chromeTargetDiscoveryStrategy.Chrom
 		});
 	}
 
-	public async getAllTargets (address: string, port: number, targetFilter?: chromeConnection.ITargetFilter, targetUrl?: string): Promise<chromeConnection.ITarget[]> {
+	public async getAllTargets (address: string, port: number): Promise<chromeConnection.ITarget[]> {
 		const target = await this.getTarget(address, port);
 		return Promise.resolve([ target ]);
 	}

--- a/src/explorer/nodes/platformNode.ts
+++ b/src/explorer/nodes/platformNode.ts
@@ -14,7 +14,7 @@ export class PlatformNode extends BaseNode {
 
 	constructor (platform: Platform) {
 		super(platform);
-		this.label = nameForPlatform(platform)!;
+		this.label = nameForPlatform(platform);
 		this.platform = platform;
 		this.contextValue = 'PlatformNode';
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -158,7 +158,12 @@ function activate (context: vscode.ExtensionContext): Promise<void> {
 		}),
 
 		vscode.commands.registerCommand(Commands.OpenAppOnDashboard, () => {
-			vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(project.dashboardUrl()!));
+			const dashboardUrl = project.dashboardUrl();
+			if (dashboardUrl) {
+				vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(dashboardUrl));
+			} else {
+				vscode.window.showErrorMessage('Unable to open project on dashboard');
+			}
 		}),
 
 		vscode.window.registerTreeDataProvider('titanium.view.buildExplorer', deviceExplorer),

--- a/src/project.ts
+++ b/src/project.ts
@@ -118,7 +118,7 @@ export class Project {
 	 * @returns {String}
 	 */
 	public pathForPlatform (platform: Platform): string|undefined {
-		const moduleInfo: any = this.modules.find((mod) => utils.normalisedPlatform(mod.platform) === platform);
+		const moduleInfo = this.modules.find((mod) => utils.normalisedPlatform(mod.platform) === platform);
 		if (moduleInfo) {
 			return moduleInfo.path;
 		}

--- a/src/project.ts
+++ b/src/project.ts
@@ -73,10 +73,11 @@ export class Project {
 	 *
 	 * @returns {String}
 	 */
-	public appId (): string|undefined {
+	public appId (): string {
 		if (this.isTitaniumApp) {
 			return String(this.tiapp.id);
 		}
+		throw new Error('Project is not a Titanium application');
 	}
 
 	/**

--- a/src/providers/completion/alloyAutoCompleteRules.ts
+++ b/src/providers/completion/alloyAutoCompleteRules.ts
@@ -46,7 +46,7 @@ export const i18nAutoComplete: AlloyAutoCompleteRule = {
 	regExp: /(L\(|titleid\s*[:=]\s*)["'](\w*["']?)$/,
 	async getCompletions () {
 		const defaultLang = ExtensionContainer.config.project.defaultI18nLanguage;
-		const i18nPath = utils.getI18nPath()!;
+		const i18nPath = utils.getI18nPath();
 		const completions: CompletionItem[] = [];
 		if (utils.directoryExists(i18nPath)) {
 			const i18nStringPath = path.join(i18nPath, defaultLang, 'strings.xml');

--- a/src/providers/completion/styleCompletionItemProvider.ts
+++ b/src/providers/completion/styleCompletionItemProvider.ts
@@ -5,7 +5,7 @@ import * as related from '../../related';
 import * as utils from '../../utils';
 import * as alloyAutoCompleteRules from './alloyAutoCompleteRules';
 
-import { CancellationToken, CompletionContext, CompletionItem, CompletionItemKind, CompletionItemProvider, Position, Range, SnippetString, TextDocument, workspace } from 'vscode';
+import { CompletionItem, CompletionItemKind, CompletionItemProvider, Position, Range, SnippetString, TextDocument, workspace } from 'vscode';
 import { Tag } from 'titanium-editor-commons/completions';
 
 /**
@@ -24,7 +24,7 @@ export class StyleCompletionItemProvider implements CompletionItemProvider {
 	 *
 	 * @returns {Thenable|Array}
 	 */
-	public async provideCompletionItems (document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): Promise<CompletionItem[]> {
+	public async provideCompletionItems (document: TextDocument, position: Position): Promise<CompletionItem[]> {
 		const linePrefix = document.getText(new Range(position.line, 0, position.line, position.character + 1));
 		const prefixRange = document.getWordRangeAtPosition(position);
 		const prefix = prefixRange ? document.getText(prefixRange) : undefined;

--- a/src/providers/completion/tiappCompletionItemProvider.ts
+++ b/src/providers/completion/tiappCompletionItemProvider.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import appc from '../../appc';
 import * as utils from '../../utils';
 
-import { CancellationToken, CompletionContext, CompletionItem, CompletionItemKind, CompletionItemProvider, Position, Range, TextDocument, workspace } from 'vscode';
+import { CompletionItem, CompletionItemKind, CompletionItemProvider, Position, Range, TextDocument, workspace } from 'vscode';
 /**
  * Tiapp.xml completion provider
  */
@@ -20,7 +20,7 @@ export class TiappCompletionItemProvider implements CompletionItemProvider {
 	 *
 	 * @returns {Thenable|Array}
 	 */
-	public provideCompletionItems (document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): CompletionItem[] {
+	public provideCompletionItems (document: TextDocument, position: Position): CompletionItem[] {
 		const linePrefix = document.getText(new Range(position.line, 0, position.line, position.character));
 		const completions: CompletionItem[] = [];
 		let tag;

--- a/src/providers/completion/viewCompletionItemProvider.ts
+++ b/src/providers/completion/viewCompletionItemProvider.ts
@@ -5,7 +5,7 @@ import * as related from '../../related';
 import * as utils from '../../utils';
 import * as alloyAutoCompleteRules from './alloyAutoCompleteRules';
 
-import { CancellationToken, CompletionContext, CompletionItem, CompletionItemKind, CompletionItemProvider, Position, Range, SnippetString, TextDocument, workspace } from 'vscode';
+import { CompletionItem, CompletionItemKind, CompletionItemProvider, Position, Range, SnippetString, TextDocument, workspace } from 'vscode';
 /**
  * Alloy View completion provider
  */
@@ -22,7 +22,7 @@ export class ViewCompletionItemProvider implements CompletionItemProvider {
 	 *
 	 * @returns {Thenable|Array}
 	 */
-	public async provideCompletionItems (document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): Promise<CompletionItem[]> {
+	public async provideCompletionItems (document: TextDocument, position: Position): Promise<CompletionItem[]> {
 		const line = document.lineAt(position).text;
 		const linePrefix = document.getText(new Range(position.line, 0, position.line, position.character));
 		const prefixRange = document.getWordRangeAtPosition(position);

--- a/src/providers/definition/common.ts
+++ b/src/providers/definition/common.ts
@@ -19,7 +19,7 @@ export interface DefinitionSuggestion {
 function getRelatedFiles(fileType: string): string[] {
 	const relatedFiles: string[] = [];
 	if (fileType === 'tss') {
-		relatedFiles.push(path.join(workspace.rootPath!, 'app', 'styles', 'app.tss'));
+		relatedFiles.push(path.join(utils.getAlloyRootPath(), 'styles', 'app.tss'));
 	}
 	const relatedFile = related.getTargetPath(fileType);
 	if (relatedFile) {
@@ -119,7 +119,7 @@ export const viewSuggestions: DefinitionSuggestion[] = [
 			return new RegExp(`name=["']${text}["']>(.*)?</`, 'g');
 		},
 		files(): string[] {
-			return [ path.join(utils.getI18nPath()!, ExtensionContainer.config.project.defaultI18nLanguage, 'strings.xml') ];
+			return [ path.join(utils.getI18nPath(), ExtensionContainer.config.project.defaultI18nLanguage, 'strings.xml') ];
 		},
 		i18nString: true
 	}

--- a/src/providers/definition/viewHoverProvider.ts
+++ b/src/providers/definition/viewHoverProvider.ts
@@ -4,7 +4,7 @@ import { CancellationToken, HoverProvider, Position, TextDocument, Hover } from 
 
 export class ViewHoverProvider implements HoverProvider {
 
-	public provideHover (document: TextDocument, position: Position, token: CancellationToken): Hover|undefined {
+	public provideHover (document: TextDocument, position: Position): Hover|undefined {
 		return definitionProviderHelper.provideHover(document, position);
 	}
 }

--- a/src/quickpicks/common.ts
+++ b/src/quickpicks/common.ts
@@ -75,7 +75,7 @@ export function selectPlatform (lastBuildDescription?: string, filter?: (platfor
 	return quickPick(platforms);
 }
 
-export async function selectCreationLocation (lastUsed?: string): Promise<Uri|undefined> {
+export async function selectCreationLocation (lastUsed?: string): Promise<Uri> {
 	const items = [ {
 		label: 'Browse for directory',
 		id: 'browse'
@@ -95,6 +95,8 @@ export async function selectCreationLocation (lastUsed?: string): Promise<Uri|un
 		return filePath[0];
 	} else if (lastUsed && directory.id === 'last') {
 		return Uri.file(lastUsed);
+	} else {
+		throw new Error('No directory was selected');
 	}
 }
 

--- a/src/quickpicks/creation.ts
+++ b/src/quickpicks/creation.ts
@@ -2,7 +2,7 @@ import { nameForPlatform, platforms } from '../utils';
 import { CustomQuickPick, quickPick } from './common';
 
 export async function selectPlatforms (): Promise<string[]> {
-	const choices: CustomQuickPick[] = platforms().map(platform => ({ label: nameForPlatform(platform)!, id: platform, picked: true }));
+	const choices: CustomQuickPick[] = platforms().map(platform => ({ label: nameForPlatform(platform), id: platform, picked: true }));
 	const selected = await quickPick(choices, { canPickMany: true, placeHolder: 'Choose platforms' });
 	return selected.map((platform: CustomQuickPick)  => platform.id);
 }

--- a/src/tasks/helpers/ios.ts
+++ b/src/tasks/helpers/ios.ts
@@ -76,7 +76,7 @@ export class IosHelper extends TaskHelper {
 			iosInfo.certificate =  getCorrectCertificateName(certificate.fullname, project.sdk()[0], IosCertificateType.developer);
 
 			if (!iosInfo.provisioningProfile) {
-				iosInfo.provisioningProfile = (await selectiOSProvisioningProfile(certificate, 'run', project.appId()!)).uuid;
+				iosInfo.provisioningProfile = (await selectiOSProvisioningProfile(certificate, 'run', project.appId())).uuid;
 			}
 
 			if (!iosInfo.provisioningProfile) {
@@ -118,7 +118,7 @@ export class IosHelper extends TaskHelper {
 		iosInfo.certificate =  getCorrectCertificateName(certificate.fullname, project.sdk()[0], IosCertificateType.distribution);
 
 		if (!iosInfo.provisioningProfile) {
-			iosInfo.provisioningProfile = (await selectiOSProvisioningProfile(certificate, definition.target, project.appId()!)).uuid!;
+			iosInfo.provisioningProfile = (await selectiOSProvisioningProfile(certificate, definition.target, project.appId())).id;
 		}
 
 		if (!iosInfo.provisioningProfile) {

--- a/src/tasks/taskPseudoTerminal.ts
+++ b/src/tasks/taskPseudoTerminal.ts
@@ -98,6 +98,8 @@ export class TaskPseudoTerminal implements vscode.Pseudoterminal {
 		ExtensionContainer.context.globalState.update(GlobalState.Running, true);
 		vscode.commands.executeCommand('setContext', GlobalState.Running, true);
 
+		// We don't want to catch here so that any errors are thrown back to the TaskProvider and handled correctly there
+		// eslint-disable-next-line promise/catch-or-return
 		this.taskProvider.executeTask(executionContext, this.task).then((result) => this.close(result));
 	}
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -77,17 +77,17 @@ export default class Terminal {
 
 				proc.stdout?.on('data', data => {
 					const message = data.toString();
-					this.channel!.append(message);
+					this.channel?.append(message);
 				});
 				proc.stderr?.on('data', data => {
 					const message = data.toString();
-					this.channel!.append(message);
+					this.channel?.append(message);
 				});
 
 				proc.on('close', code => {
 					if (code) {
 						window.showErrorMessage('Failed to create the application, please check the output.');
-						this.channel!.show();
+						this.channel?.show();
 						return reject();
 					}
 					return resolve();
@@ -139,16 +139,16 @@ export default class Terminal {
 			ExtensionContainer.context.globalState.update(GlobalState.Running, true);
 			commands.executeCommand('setContext', GlobalState.Running, true);
 			const message = data.toString();
-			this.channel!.append(message);
+			this.channel?.append(message);
 		});
 		this.proc.stderr?.on('data', data => {
 			const message = data.toString();
-			this.channel!.append(message);
+			this.channel?.append(message);
 		});
-		this.proc.on('close', data => {
+		this.proc.on('close', () => {
 			this.proc = undefined;
 		});
-		this.proc.on('exit', data => {
+		this.proc.on('exit', () => {
 			ExtensionContainer.context.globalState.update(GlobalState.Running, false);
 			commands.executeCommand('setContext', GlobalState.Running, false);
 			this.proc = undefined;

--- a/src/test/suite/controllerAutoCompleteProvider.test.ts
+++ b/src/test/suite/controllerAutoCompleteProvider.test.ts
@@ -18,11 +18,7 @@ const completions = JSON.parse(rawData);
 async function testCompletion (position: vscode.Position): Promise<vscode.CompletionItem[]> {
 	const text = await vscode.workspace.openTextDocument(uri);
 	const provider = new ControllerCompletionItemProvider();
-	const context: vscode.CompletionContext = {
-		triggerKind: vscode.CompletionTriggerKind.Invoke,
-	};
-	const cancellationToken = new vscode.CancellationTokenSource();
-	return provider.provideCompletionItems(text, position, cancellationToken.token, context);
+	return provider.provideCompletionItems(text, position);
 }
 
 let sandbox: sinon.SinonSandbox;

--- a/src/test/suite/styleAutoCompleteProvider.test.ts
+++ b/src/test/suite/styleAutoCompleteProvider.test.ts
@@ -19,11 +19,7 @@ const completions = JSON.parse(rawData);
 async function testCompletion (position: vscode.Position): Promise<vscode.CompletionItem[]> {
 	const text = await vscode.workspace.openTextDocument(uri);
 	const provider = new StyleCompletionItemProvider();
-	const context: vscode.CompletionContext = {
-		triggerKind: vscode.CompletionTriggerKind.Invoke,
-	};
-	const cancellationToken = new vscode.CancellationTokenSource();
-	return provider.provideCompletionItems(text, position, cancellationToken.token, context);
+	return provider.provideCompletionItems(text, position);
 }
 let sandbox: sinon.SinonSandbox;
 

--- a/src/test/suite/viewAutoCompleteProvider.test.ts
+++ b/src/test/suite/viewAutoCompleteProvider.test.ts
@@ -18,11 +18,7 @@ const completions = JSON.parse(rawData);
 async function testCompletion (position: vscode.Position): Promise<vscode.CompletionItem[]> {
 	const text = await vscode.workspace.openTextDocument(uri);
 	const provider = new ViewCompletionItemProvider();
-	const context: vscode.CompletionContext = {
-		triggerKind: vscode.CompletionTriggerKind.Invoke,
-	};
-	const cancellationToken = new vscode.CancellationTokenSource();
-	return provider.provideCompletionItems(text, position, cancellationToken.token, context);
+	return provider.provideCompletionItems(text, position);
 }
 let sandbox: sinon.SinonSandbox;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,13 +57,15 @@ export function platforms (): string[] {
  * @param {String} targetPlatform - target platform.
  * @returns {String}
  */
-export function nameForPlatform (targetPlatform: string): PlatformPretty|undefined {
+export function nameForPlatform (targetPlatform: string): PlatformPretty {
 	targetPlatform =  normalisedPlatform(targetPlatform);
 	switch (targetPlatform) {
 		case 'android':
 			return PlatformPretty.android;
 		case 'ios':
 			return PlatformPretty.ios;
+		default:
+			throw new Error(`Unknown platform ${targetPlatform}`);
 	}
 }
 


### PR DESCRIPTION
This brings us down to around 61 warnings from around 119. That's still a good chunk of warnings, but I focused on things I can fix within a couple minutes and avoided anything that requires significant refactors like `workspace.rootPath` for example.

I tried to group related fixes so that's why there's a bunch of commits. We can just squash this PR on merge as they're not all necessary.