### PR TITLE
Fix integration tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -80,6 +80,18 @@
                 "order": 1
             }
         },
+        {
+            "name": "Extension UI Tests",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceFolder}/out/test/integration/runTests.js",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "presentation": {
+                "group": "2_tests",
+                "order": 1
+            }
+        }
     ],
     "compounds": [
         {

--- a/src/commands/alloyGenerate.ts
+++ b/src/commands/alloyGenerate.ts
@@ -55,7 +55,7 @@ Promise<{ cwd: string; filePaths: string[]; name: string; type: AlloyComponentTy
 		filePaths.push(mainFile);
 	}
 	if (await fs.pathExists(mainFile)) {
-		const shouldDelete = await quickPick([ { id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' } ], { placeHolder: ` ${name} already exists. Overwrite it?` });
+		const shouldDelete = await quickPick([ { id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' } ], { placeHolder: `${name} already exists. Overwrite it?` });
 		if (shouldDelete.id === 'no') {
 			throw new UserCancellation();
 		}

--- a/src/test/integration/suite/alloy/generate.test.ts
+++ b/src/test/integration/suite/alloy/generate.test.ts
@@ -64,10 +64,13 @@ describe('Alloy component generation', function () {
 	it('should prompt if already exists', async function () {
 		const workbench = new Workbench();
 		await workbench.executeCommand('Titanium: Generate Alloy controller');
-		await generator.setName('existing-file');
+		await generator.setName('existing-file', 'controller');
 
 		const input = await InputBox.create();
-		console.log(input.getMessage());
+
+		const placeHolderText = await input.getPlaceHolder();
+		expect(placeHolderText).to.include('existing-file already exists. Overwrite it?', 'Did not prompt to force creation');
+
 		await input.setText('No');
 		await input.confirm();
 

--- a/src/test/integration/util/alloy-generate.ts
+++ b/src/test/integration/util/alloy-generate.ts
@@ -1,13 +1,15 @@
 import { InputBox } from 'vscode-extension-tester';
 import { notificationExists, CommonUICreator } from './common';
 import { capitalizeFirstLetter } from '../util/common';
+import { expect } from 'chai';
 
 export class AlloyGenerate extends CommonUICreator {
 
 	async generateComponent(type: string, name: string, force = false): Promise<void> {
 
 		await this.workbench.executeCommand(`Titanium: Generate Alloy ${type}`);
-		await this.setName(name);
+
+		await this.setName(name, type);
 		if (force) {
 			// todo
 		}
@@ -15,8 +17,12 @@ export class AlloyGenerate extends CommonUICreator {
 		await this.driver.wait(() => notificationExists(`${capitalizeFirstLetter(type)} ${name} created successfully`), 7500);
 	}
 
-	async setName (name: string): Promise<void> {
+	async setName (name: string, type: string): Promise<void> {
 		const input = await InputBox.create();
+
+		const message = await input.getMessage();
+		expect(message).to.include(`Enter the name for your ${type}`, 'Did not prompt for name');
+
 		await input.setText(name);
 		await input.confirm();
 	}

--- a/src/test/integration/util/create.ts
+++ b/src/test/integration/util/create.ts
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 export class ProjectCreator extends CommonUICreator {
 
 	public async createApp(options: AppCreateOptions): Promise<void> {
-		await this.workbench.executeCommand('Titanium: Create Titanium application');
+		await this.workbench.executeCommand('Titanium: Create application');
 
 		await this.setName(options.name);
 		await this.setId(options.id);
@@ -42,7 +42,7 @@ export class ProjectCreator extends CommonUICreator {
 	}
 
 	public async createModule (options: ModuleCreateOptions): Promise<void> {
-		await this.workbench.executeCommand('Titanium: Create Titanium module');
+		await this.workbench.executeCommand('Titanium: Create module');
 
 		await this.setName(options.name);
 		await this.setId(options.id);

--- a/src/test/integration/util/create.ts
+++ b/src/test/integration/util/create.ts
@@ -1,5 +1,6 @@
 import { InputBox } from 'vscode-extension-tester';
 import { notificationExists, CommonUICreator } from './common';
+import { expect } from 'chai';
 
 /**
  * Wrapper around the project creation flow to make it slightly easier to test
@@ -77,6 +78,10 @@ export class ProjectCreator extends CommonUICreator {
 	public async setEnableServices(enableServices: boolean): Promise<void> {
 		const servicesText = enableServices ? 'Yes' : 'No';
 		const input = await InputBox.create();
+
+		const placeHolderText = await input.getPlaceHolder();
+		expect(placeHolderText).to.equal('Enable services?', 'Did not show enable services prompt');
+
 		await input.setText(servicesText);
 		await input.confirm();
 		await this.driver.sleep(100);
@@ -84,6 +89,10 @@ export class ProjectCreator extends CommonUICreator {
 
 	public async setFolder(folder: string): Promise<void> {
 		const input = await InputBox.create();
+
+		const placeHolderText = await input.getPlaceHolder();
+		expect(placeHolderText).to.equal('Browse for directory or use last directory', 'Did not show folder selection');
+
 		await input.setText('Enter');
 		await input.confirm();
 
@@ -93,18 +102,30 @@ export class ProjectCreator extends CommonUICreator {
 
 	public async setId(id: string): Promise<void> {
 		const input = await InputBox.create();
+
+		const message = await input.getMessage();
+		expect(message).to.match(/Enter your (application|module) ID/, 'Did not show ID input');
+
 		await input.setText(id);
 		await input.confirm();
 	}
 
 	public async setName (name: string): Promise<void> {
 		const input = await InputBox.create();
+
+		const message = await input.getMessage();
+		expect(message).to.match(/Enter your (application|module) name/, 'Did not show name input');
+
 		await input.setText(name);
 		await input.confirm();
 	}
 
 	public async setPlatforms(platforms: string[]): Promise<void> {
 		const input = await InputBox.create();
+
+		const placeHolderText = await input.getPlaceHolder();
+		expect(placeHolderText).to.equal('Choose platforms', 'Did not show platform selection');
+
 		const choices = await input.getQuickPicks();
 		for (const choice of choices) {
 			const text = await choice.getText();

--- a/src/types/telemetry.ts
+++ b/src/types/telemetry.ts
@@ -1,0 +1,1 @@
+// import { Event } from 'titanium-editor-commons/telemetry';


### PR DESCRIPTION
* Move to a pattern where we check that the right prompt is shown before attempting to input text, that should allow us to track down issues easier
* Fix the command names for creating apps/modules, was changed in #366 (to be pushed after I've tested how these failures look in Jenkins)