### PR TITLE
feat(create): allow setting a default path for project

### DIFF
--- a/package.json
+++ b/package.json
@@ -408,6 +408,10 @@
           "default": "\\n'${text}': {\\n}\\n",
           "description": "Style tag template"
         },
+        "titanium.general.defaultCreationDirectory": {
+          "type": "string",
+          "description": "Default directory to use when creating projects"
+        },
         "titanium.general.appcCommandPath": {
           "type": "string",
           "default": "appc",

--- a/src/test/integration/util/common.ts
+++ b/src/test/integration/util/common.ts
@@ -1,4 +1,4 @@
-import { BottomBarPanel, InputBox, Notification, Workbench, WebDriver } from 'vscode-extension-tester';
+import { BottomBarPanel, InputBox, Notification, Workbench, WebDriver, TextSetting } from 'vscode-extension-tester';
 import { promisify } from 'util';
 import  * as cp from 'child_process';
 import * as path from 'path';
@@ -81,6 +81,13 @@ export class CommonUICreator {
 			setTimeout(resolve, 2000);
 		});
 	}
+
+	public async configureSetting(section: string, settingName: string, value: string): Promise<void> {
+		const editor = await this.workbench.openSettings();
+
+		const setting = await editor.findSetting(settingName, `Titanium › ${section}`) as TextSetting;
+		await setting.setValue(value);
+	}
 }
 
 /**
@@ -100,6 +107,6 @@ export function getFixturesDirectory (): string {
  * @param {String} s - string.
  * @returns {String}
  */
-export function  capitalizeFirstLetter (s: string): string {
+export function capitalizeFirstLetter (s: string): string {
 	return s.charAt(0).toUpperCase() + s.slice(1);
 }

--- a/src/test/integration/util/create.ts
+++ b/src/test/integration/util/create.ts
@@ -8,13 +8,16 @@ import { expect } from 'chai';
 export class ProjectCreator extends CommonUICreator {
 
 	public async createApp(options: AppCreateOptions): Promise<void> {
+		// We need to configure the setting for the creation directory before running any commands
+		await this.configureSetting('General', 'Default Creation Directory', options.folder);
+
 		await this.workbench.executeCommand('Titanium: Create application');
 
 		await this.setName(options.name);
 		await this.setId(options.id);
 		await this.setPlatforms(options.platforms);
 		await this.setEnableServices(options.enableServices);
-		await this.setFolder(options.folder);
+		await this.setFolder();
 
 		try {
 			await this.driver.wait(() => notificationExists('Creating application'), 1000);
@@ -42,12 +45,15 @@ export class ProjectCreator extends CommonUICreator {
 	}
 
 	public async createModule (options: ModuleCreateOptions): Promise<void> {
+		// We need to configure the setting for the creation directory before running any commands
+		await this.configureSetting('General', 'Default Creation Directory', options.folder);
+
 		await this.workbench.executeCommand('Titanium: Create module');
 
 		await this.setName(options.name);
 		await this.setId(options.id);
 		await this.setPlatforms(options.platforms);
-		await this.setFolder(options.folder);
+		await this.setFolder();
 
 		try {
 			await this.driver.wait(() => notificationExists('Creating module'), 1000);
@@ -87,16 +93,13 @@ export class ProjectCreator extends CommonUICreator {
 		await this.driver.sleep(100);
 	}
 
-	public async setFolder(folder: string): Promise<void> {
+	public async setFolder(): Promise<void> {
 		const input = await InputBox.create();
 
 		const placeHolderText = await input.getPlaceHolder();
-		expect(placeHolderText).to.equal('Browse for directory or use last directory', 'Did not show folder selection');
+		expect(placeHolderText).to.equal('Select where to create your project', 'Did not show folder selection');
 
-		await input.setText('Enter');
-		await input.confirm();
-
-		await input.setText(folder);
+		await input.setText('Default');
 		await input.confirm();
 	}
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -16,6 +16,7 @@ export interface Config {
 	};
 	general: {
 		appcCommandPath: string;
+		defaultCreationDirectory?: string;
 		displayBuildCommandInConsole: boolean;
 		logLevel: LogLevel;
 		useTerminalForBuild: boolean;


### PR DESCRIPTION
Closes [EDITOR-53](https://jira.appcelerator.org/browse/EDITOR-53)

Reworks the quick fix for inputting a folder that was put in place to get the integration tests going.

There's no clean way to have a quick-pick function as a selection and input box, so rather than allow inputting the path directly I decided to rework the feature into allowing a default creation path to be set. We configure that before running the tests and then set the path as needed on each test run