### PR TITLE
Add refresh devices option on device selection, refactor build quickpicks into separate files

### DIFF
--- a/src/explorer/tiExplorer.ts
+++ b/src/explorer/tiExplorer.ts
@@ -14,8 +14,8 @@ export default class DeviceExplorer implements vscode.TreeDataProvider<BaseNode>
 
 	private platforms: Map<string, PlatformNode> = new Map();
 
-	public refresh (): void {
-		vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: 'Reading Appcelerator environment ...' }, () => {
+	public async refresh (): Promise<void> {
+		return vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: 'Reading Appcelerator environment ...' }, () => {
 			return new Promise((resolve, reject) => {
 				appc.getInfo((error, info) => {
 					if (info) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,8 +168,8 @@ function activate (context: vscode.ExtensionContext): Promise<void> {
 
 		vscode.window.registerTreeDataProvider('titanium.view.buildExplorer', deviceExplorer),
 
-		vscode.commands.registerCommand(Commands.RefreshExplorer, () => {
-			deviceExplorer.refresh();
+		vscode.commands.registerCommand(Commands.RefreshExplorer, async () => {
+			await deviceExplorer.refresh();
 		}),
 
 		vscode.window.registerTreeDataProvider('titanium.view.updateExplorer', updateExplorer),

--- a/src/quickpicks/build/android.ts
+++ b/src/quickpicks/build/android.ts
@@ -1,18 +1,19 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import appc from '../../appc';
-import { enterPassword, inputBox, quickPick, CustomQuickPick } from '../common';
+import { enterPassword, inputBox, quickPick } from '../common';
 import { InteractionError, UserCancellation } from '../../commands';
 import { pathExists } from 'fs-extra';
 import { ExtensionContainer } from '../../container';
 import { KeystoreInfo } from '../../types/common';
+import { deviceQuickPick, DeviceQuickPickItem } from './common';
 
-export function selectAndroidDevice (): Promise<CustomQuickPick & { udid: string }> {
+export function selectAndroidDevice (): Promise<DeviceQuickPickItem> {
 	const devices = appc.androidDevices().map(({ id, name }: { id: string; name: string }) => ({ id, label: name, udid: id }));
-	return quickPick(devices)  as Promise<CustomQuickPick & { udid: string }>;
+	return deviceQuickPick(devices, { placeHolder: 'Select Android device' });
 }
 
-export function selectAndroidEmulator (): Promise<CustomQuickPick & { udid: string }>  {
+export function selectAndroidEmulator (): Promise<DeviceQuickPickItem>  {
 	const emulators = appc.androidEmulators();
 	const options = [];
 
@@ -32,7 +33,7 @@ export function selectAndroidEmulator (): Promise<CustomQuickPick & { udid: stri
 		});
 	}
 
-	return quickPick(options, { placeHolder: 'Select emulator' })  as Promise<CustomQuickPick & { udid: string }>;
+	return deviceQuickPick(options, { placeHolder: 'Select emulator' });
 }
 
 export async function selectAndroidKeystore (lastUsed?: string, savedKeystorePath?: string): Promise<string|undefined> {

--- a/src/quickpicks/build/android.ts
+++ b/src/quickpicks/build/android.ts
@@ -1,0 +1,88 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import appc from '../../appc';
+import { enterPassword, inputBox, quickPick, CustomQuickPick } from '../common';
+import { InteractionError, UserCancellation } from '../../commands';
+import { pathExists } from 'fs-extra';
+import { ExtensionContainer } from '../../container';
+import { KeystoreInfo } from '../../types/common';
+
+export function selectAndroidDevice (): Promise<CustomQuickPick & { udid: string }> {
+	const devices = appc.androidDevices().map(({ id, name }: { id: string; name: string }) => ({ id, label: name, udid: id }));
+	return quickPick(devices)  as Promise<CustomQuickPick & { udid: string }>;
+}
+
+export function selectAndroidEmulator (): Promise<CustomQuickPick & { udid: string }>  {
+	const emulators = appc.androidEmulators();
+	const options = [];
+
+	for (const emulator of emulators.AVDs) {
+		options.push({
+			id: emulator.id,
+			udid: emulator.id,
+			label: emulator.name
+		});
+	}
+
+	for (const emulator of emulators.Genymotion) {
+		options.push({
+			id: emulator.id,
+			udid: emulator.id,
+			label: emulator.name
+		});
+	}
+
+	return quickPick(options, { placeHolder: 'Select emulator' })  as Promise<CustomQuickPick & { udid: string }>;
+}
+
+export async function selectAndroidKeystore (lastUsed?: string, savedKeystorePath?: string): Promise<string|undefined> {
+	const items = [ {
+		label: 'Browse for keystore',
+		id: 'browse'
+	} ];
+	if (lastUsed) {
+		items.push({
+			label: `Last used ${lastUsed}`,
+			id: 'last'
+		});
+	}
+	if (savedKeystorePath) {
+		items.push({
+			label: `Saved ${savedKeystorePath}`,
+			id: 'saved'
+		});
+	}
+	const keystoreAction = await quickPick(items, { placeHolder: 'Browse for keystore or use last keystore' });
+	if (keystoreAction.id === 'browse') {
+		const uri = await vscode.window.showOpenDialog({ canSelectFolders: false, canSelectMany: false });
+		if (!uri) {
+			throw new UserCancellation();
+		}
+		return uri[0].path;
+	} else if (savedKeystorePath && keystoreAction.id === 'saved') {
+		if (!path.isAbsolute(savedKeystorePath)) {
+			savedKeystorePath = path.resolve(vscode.workspace.rootPath!, savedKeystorePath);
+		}
+		return savedKeystorePath;
+	} else if (lastUsed) {
+		return lastUsed;
+	}
+}
+
+export async function enterAndroidKeystoreInfo (lastUsed?: string, savedKeystorePath?: string): Promise<KeystoreInfo> {
+	const location = await selectAndroidKeystore(lastUsed, savedKeystorePath);
+
+	if (!location || !await pathExists(location)) {
+		throw new InteractionError(`The Keystore file ${location} does not exist`);
+	}
+	const alias = await inputBox({ placeHolder: 'Enter your keystore alias', value: ExtensionContainer.config.android.keystoreAlias || '' });
+	const password = await enterPassword({ placeHolder: 'Enter your keystore password' });
+	const privateKeyPassword = await enterPassword({ placeHolder: 'Enter your keystore private key password (optional)' });
+
+	return {
+		alias,
+		location,
+		password,
+		privateKeyPassword
+	};
+}

--- a/src/quickpicks/build/common.ts
+++ b/src/quickpicks/build/common.ts
@@ -1,10 +1,21 @@
+import { QuickPickOptions } from 'vscode';
 import * as utils from '../../utils';
 
 import { quickPick, CustomQuickPick } from '../common';
 import { selectAndroidDevice, selectAndroidEmulator } from './android';
-import { selectiOSDevice, selectiOSSimulator, selectiOSSimulatorVersion } from './ios';
+import { selectiOSDevice, selectiOSSimulator } from './ios';
 
-export async function selectDevice (platform: string, target: string): Promise<CustomQuickPick> {
+export interface DeviceQuickPickItem extends CustomQuickPick {
+	id: string;
+	label: string;
+	udid: string;
+}
+
+export async function deviceQuickPick (deviceList: DeviceQuickPickItem[], quickPickOptions: QuickPickOptions): Promise<DeviceQuickPickItem> {
+	return quickPick(deviceList, quickPickOptions) as Promise<DeviceQuickPickItem>;
+}
+
+export async function selectDevice (platform: string, target: string, iOSSimulatorVersion?: string): Promise<DeviceQuickPickItem> {
 	if (platform === 'android' && target === 'emulator') {
 		return selectAndroidEmulator();
 	} else if (platform === 'android' && target === 'device') {
@@ -12,10 +23,9 @@ export async function selectDevice (platform: string, target: string): Promise<C
 	} else if (platform === 'ios' && target === 'device') {
 		return selectiOSDevice();
 	} else if (platform === 'ios' && target === 'simulator') {
-		const simVersion = await selectiOSSimulatorVersion();
-		return selectiOSSimulator(simVersion.label);
+		return selectiOSSimulator(iOSSimulatorVersion);
 	} else {
-		throw new Error(`Unsupported platform and combination target ${platform} + ${target}`);
+		throw new Error(`Unknown platform "${platform}" or target "${target}"`);
 	}
 }
 

--- a/src/quickpicks/build/common.ts
+++ b/src/quickpicks/build/common.ts
@@ -21,7 +21,7 @@ export async function deviceQuickPick (deviceList: DeviceQuickPickItem[], quickP
 		label: 'Refresh Devices',
 		udid: 'refresh'
 	});
-	return quickPick(deviceList, quickPickOptions, { forceShow: true }) as Promise<DeviceQuickPickItem>;
+	return quickPick<DeviceQuickPickItem>(deviceList, quickPickOptions, { forceShow: true });
 }
 
 export async function selectDevice (platform: string, target: string, iOSSimulatorVersion?: string): Promise<DeviceQuickPickItem> {

--- a/src/quickpicks/build/common.ts
+++ b/src/quickpicks/build/common.ts
@@ -1,0 +1,34 @@
+import * as utils from '../../utils';
+
+import { quickPick, CustomQuickPick } from '../common';
+import { selectAndroidDevice, selectAndroidEmulator } from './android';
+import { selectiOSDevice, selectiOSSimulator, selectiOSSimulatorVersion } from './ios';
+
+export async function selectDevice (platform: string, target: string): Promise<CustomQuickPick> {
+	if (platform === 'android' && target === 'emulator') {
+		return selectAndroidEmulator();
+	} else if (platform === 'android' && target === 'device') {
+		return selectAndroidDevice();
+	} else if (platform === 'ios' && target === 'device') {
+		return selectiOSDevice();
+	} else if (platform === 'ios' && target === 'simulator') {
+		const simVersion = await selectiOSSimulatorVersion();
+		return selectiOSSimulator(simVersion.label);
+	} else {
+		throw new Error(`Unsupported platform and combination target ${platform} + ${target}`);
+	}
+}
+
+export function selectBuildTarget (platform: string): Promise<CustomQuickPick>  {
+	const targets = utils.targetsForPlatform(platform)
+		.filter(target => !/^dist/.test(target))
+		.map(target => ({ label: utils.nameForTarget(target), id: target }));
+	return quickPick(targets);
+}
+
+export function selectDistributionTarget (platform: string): Promise<CustomQuickPick>  {
+	const targets = utils.targetsForPlatform(platform)
+		.filter(target => /^dist/.test(target))
+		.map(target => ({ label: utils.nameForTarget(target), id: target }));
+	return quickPick(targets);
+}

--- a/src/quickpicks/build/ios.ts
+++ b/src/quickpicks/build/ios.ts
@@ -1,6 +1,7 @@
 import appc from '../../appc';
 import { IosCertificateType } from '../../types/common';
 import { quickPick, CustomQuickPick } from '../common';
+import { deviceQuickPick, DeviceQuickPickItem } from './common';
 
 export function selectiOSCertificate (buildType: string): Promise<CustomQuickPick> {
 	const certificateType: IosCertificateType = buildType === 'run' ? IosCertificateType.developer : IosCertificateType.distribution;
@@ -40,9 +41,9 @@ export async function selectiOSCodeSigning (buildType: string, target: string, a
 	};
 }
 
-export function selectiOSDevice (): Promise<CustomQuickPick & { udid: string }> {
+export function selectiOSDevice (): Promise<DeviceQuickPickItem> {
 	const devices = appc.iOSDevices().map(device => ({ id: device.udid, label: device.name, udid: device.udid }));
-	return quickPick(devices, { placeHolder: 'Select device' }) as Promise<CustomQuickPick & { udid: string }>;
+	return deviceQuickPick(devices, { placeHolder: 'Select device' });
 }
 
 export function selectiOSSimulatorVersion (): Promise<CustomQuickPick> {
@@ -50,7 +51,7 @@ export function selectiOSSimulatorVersion (): Promise<CustomQuickPick> {
 	return quickPick(versions, { placeHolder: 'Select simulator version' });
 }
 
-export async function selectiOSSimulator (iOSVersion?: string): Promise<CustomQuickPick & { udid: string }> {
+export async function selectiOSSimulator (iOSVersion?: string): Promise<DeviceQuickPickItem> {
 	if (!iOSVersion) {
 		iOSVersion = (await selectiOSSimulatorVersion()).label; // eslint-disable-line require-atomic-updates
 	}
@@ -58,5 +59,5 @@ export async function selectiOSSimulator (iOSVersion?: string): Promise<CustomQu
 		throw new Error(`iOS Version ${iOSVersion} does not exist`);
 	}
 	const simulators = appc.iOSSimulators()[iOSVersion].map(({ name, udid }) => ({ label: `${name} (${iOSVersion})`, id: udid, udid, version: iOSVersion }));
-	return quickPick(simulators, { placeHolder: 'Select simulator' }) as Promise<CustomQuickPick & { udid: string }>;
+	return deviceQuickPick(simulators, { placeHolder: 'Select simulator' });
 }

--- a/src/quickpicks/build/ios.ts
+++ b/src/quickpicks/build/ios.ts
@@ -1,0 +1,62 @@
+import appc from '../../appc';
+import { IosCertificateType } from '../../types/common';
+import { quickPick, CustomQuickPick } from '../common';
+
+export function selectiOSCertificate (buildType: string): Promise<CustomQuickPick> {
+	const certificateType: IosCertificateType = buildType === 'run' ? IosCertificateType.developer : IosCertificateType.distribution;
+	const certificates = appc.iOSCertificates(certificateType).map(cert => ({
+		description: `Expires: ${new Date(cert.after).toLocaleString('en-US')}`,
+		label: cert.fullname,
+		pem: cert.pem,
+		id: cert.fullname
+	}));
+	return quickPick(certificates, { placeHolder: 'Select certificate' });
+}
+
+export function selectiOSProvisioningProfile (certificate: any, target: string, appId: string): Promise<CustomQuickPick> {
+	let deployment = 'development';
+	if (target === 'dist-adhoc') {
+		deployment = 'distribution';
+	} else if (target === 'dist-appstore') {
+		deployment = 'appstore';
+	}
+	const profiles = appc.iOSProvisioningProfiles(deployment, certificate, appId).map(({ expirationDate, name, uuid }) => ({
+		description: uuid,
+		detail: `Expires: ${new Date(expirationDate).toLocaleString('en-US')}`,
+		label: name,
+		uuid,
+		id: uuid
+	}));
+	return quickPick(profiles, { placeHolder: 'Select provisioning profile' });
+}
+
+export async function selectiOSCodeSigning (buildType: string, target: string, appId: string): Promise<{ certificate: CustomQuickPick; provisioningProfile: CustomQuickPick & { uuid: string } }> {
+	const certificate = await selectiOSCertificate(buildType);
+
+	const provisioningProfile = await selectiOSProvisioningProfile(certificate, target, appId) as CustomQuickPick & { uuid: string };
+	return {
+		certificate,
+		provisioningProfile
+	};
+}
+
+export function selectiOSDevice (): Promise<CustomQuickPick & { udid: string }> {
+	const devices = appc.iOSDevices().map(device => ({ id: device.udid, label: device.name, udid: device.udid }));
+	return quickPick(devices, { placeHolder: 'Select device' }) as Promise<CustomQuickPick & { udid: string }>;
+}
+
+export function selectiOSSimulatorVersion (): Promise<CustomQuickPick> {
+	const versions = appc.iOSSimulatorVersions().map(version => ({ id: version, label: version }));
+	return quickPick(versions, { placeHolder: 'Select simulator version' });
+}
+
+export async function selectiOSSimulator (iOSVersion?: string): Promise<CustomQuickPick & { udid: string }> {
+	if (!iOSVersion) {
+		iOSVersion = (await selectiOSSimulatorVersion()).label; // eslint-disable-line require-atomic-updates
+	}
+	if (!appc.iOSSimulatorVersions().includes(iOSVersion)) {
+		throw new Error(`iOS Version ${iOSVersion} does not exist`);
+	}
+	const simulators = appc.iOSSimulators()[iOSVersion].map(({ name, udid }) => ({ label: `${name} (${iOSVersion})`, id: udid, udid, version: iOSVersion }));
+	return quickPick(simulators, { placeHolder: 'Select simulator' }) as Promise<CustomQuickPick & { udid: string }>;
+}

--- a/src/quickpicks/common.ts
+++ b/src/quickpicks/common.ts
@@ -15,6 +15,10 @@ export interface CustomQuickPick extends QuickPickItem {
 	uuid?: string;
 }
 
+interface CustomQuickPickOptions {
+	forceShow: boolean;
+}
+
 export async function inputBox (options: InputBoxOptions): Promise<string> {
 	const input = await window.showInputBox(options);
 
@@ -48,9 +52,11 @@ export async function yesNoQuestion (options: QuickPickOptions, shouldThrow = fa
 	}
 }
 
-export async function quickPick (items: CustomQuickPick[], quickPickOptions: QuickPickOptions & { canPickMany: true }, customQuickPickOptions?: { forceShow: boolean }): Promise<CustomQuickPick[]>;
-export async function quickPick (items: CustomQuickPick[], quickPickOptions?: QuickPickOptions, customQuickPickOptions?: { forceShow: boolean }): Promise<CustomQuickPick>;
-export async function quickPick (items: string[], quickPickOptions?: QuickPickOptions, customQuickPickOptions?: { forceShow: boolean }): Promise<string>;
+export async function quickPick(items: string[], quickPickOptions?: QuickPickOptions & { canPickMany: true }, customQuickPickOptions?: CustomQuickPickOptions): Promise<string[]>;
+export async function quickPick(items: CustomQuickPick[], quickPickOptions?: QuickPickOptions & { canPickMany: true }, customQuickPickOptions?: CustomQuickPickOptions): Promise<CustomQuickPick[]>;
+export async function quickPick(items: string[], quickPickOptions?: QuickPickOptions, customQuickPickOptions?: CustomQuickPickOptions): Promise<string>;
+export async function quickPick(items: CustomQuickPick[], quickPickOptions?: QuickPickOptions, customQuickPickOptions?: CustomQuickPickOptions): Promise<CustomQuickPick>;
+export async function quickPick<T extends CustomQuickPick>(items: T[], quickPickOptions?: QuickPickOptions, customQuickPickOptions?: CustomQuickPickOptions): Promise<T>;
 export async function quickPick<T extends CustomQuickPick> (items: T[], quickPickOptions?: QuickPickOptions, { forceShow = false } = {}): Promise<T> {
 	if (items.length === 1 && !forceShow) {
 		return items[0];

--- a/src/quickpicks/common.ts
+++ b/src/quickpicks/common.ts
@@ -51,7 +51,7 @@ export async function yesNoQuestion (options: QuickPickOptions, shouldThrow = fa
 export async function quickPick (items: CustomQuickPick[], quickPickOptions: QuickPickOptions & { canPickMany: true }, customQuickPickOptions?: { forceShow: boolean }): Promise<CustomQuickPick[]>;
 export async function quickPick (items: CustomQuickPick[], quickPickOptions?: QuickPickOptions, customQuickPickOptions?: { forceShow: boolean }): Promise<CustomQuickPick>;
 export async function quickPick (items: string[], quickPickOptions?: QuickPickOptions, customQuickPickOptions?: { forceShow: boolean }): Promise<string>;
-export async function quickPick<T extends QuickPickItem> (items: T[], quickPickOptions?: QuickPickOptions, { forceShow = false } = {}): Promise<T> {
+export async function quickPick<T extends CustomQuickPick> (items: T[], quickPickOptions?: QuickPickOptions, { forceShow = false } = {}): Promise<T> {
 	if (items.length === 1 && !forceShow) {
 		return items[0];
 	}

--- a/src/quickpicks/common.ts
+++ b/src/quickpicks/common.ts
@@ -1,13 +1,11 @@
-import * as path from 'path';
-import appc from '../appc';
 import * as utils from '../utils';
 
 import { pathExists, ensureDir } from 'fs-extra';
 import { UpdateInfo } from 'titanium-editor-commons/updates';
-import { InputBoxOptions, QuickPickItem, QuickPickOptions, Uri, window, workspace } from 'vscode';
-import { InteractionError, UserCancellation } from '../commands/common';
+import { InputBoxOptions, QuickPickItem, QuickPickOptions, Uri, window } from 'vscode';
+import { UserCancellation } from '../commands/common';
 import { ExtensionContainer } from '../container';
-import { IosCertificateType, UpdateChoice, KeystoreInfo } from '../types/common';
+import { UpdateChoice } from '../types/common';
 
 export interface CustomQuickPick extends QuickPickItem {
 	label: string;
@@ -124,159 +122,6 @@ export async function selectCreationLocation (lastUsed?: string): Promise<Uri> {
 	}
 }
 
-export function selectBuildTarget (platform: string): Promise<CustomQuickPick>  {
-	const targets = utils.targetsForPlatform(platform)
-		.filter(target => !/^dist/.test(target))
-		.map(target => ({ label: utils.nameForTarget(target), id: target }));
-	return quickPick(targets);
-}
-
-export function selectDistributionTarget (platform: string): Promise<CustomQuickPick>  {
-	const targets = utils.targetsForPlatform(platform)
-		.filter(target => /^dist/.test(target))
-		.map(target => ({ label: utils.nameForTarget(target), id: target }));
-	return quickPick(targets);
-}
-
-export function selectAndroidDevice (): Promise<CustomQuickPick & { udid: string }> {
-	const devices = appc.androidDevices().map(({ id, name }: { id: string; name: string }) => ({ id, label: name, udid: id }));
-	return quickPick(devices)  as Promise<CustomQuickPick & { udid: string }>;
-}
-
-export function selectAndroidEmulator (): Promise<CustomQuickPick & { udid: string }>  {
-	const emulators = appc.androidEmulators();
-	const options = [];
-
-	for (const emulator of emulators.AVDs) {
-		options.push({
-			id: emulator.id,
-			udid: emulator.id,
-			label: emulator.name
-		});
-	}
-
-	for (const emulator of emulators.Genymotion) {
-		options.push({
-			id: emulator.id,
-			udid: emulator.id,
-			label: emulator.name
-		});
-	}
-
-	return quickPick(options, { placeHolder: 'Select emulator' })  as Promise<CustomQuickPick & { udid: string }>;
-}
-
-export async function selectAndroidKeystore (lastUsed?: string, savedKeystorePath?: string): Promise<string|undefined> {
-	const items = [ {
-		label: 'Browse for keystore',
-		id: 'browse'
-	} ];
-	if (lastUsed) {
-		items.push({
-			label: `Last used ${lastUsed}`,
-			id: 'last'
-		});
-	}
-	if (savedKeystorePath) {
-		items.push({
-			label: `Saved ${savedKeystorePath}`,
-			id: 'saved'
-		});
-	}
-	const keystoreAction = await quickPick(items, { placeHolder: 'Browse for keystore or use last keystore' });
-	if (keystoreAction.id === 'browse') {
-		const uri = await window.showOpenDialog({ canSelectFolders: false, canSelectMany: false });
-		if (!uri) {
-			throw new UserCancellation();
-		}
-		return uri[0].path;
-	} else if (savedKeystorePath && keystoreAction.id === 'saved') {
-		if (!path.isAbsolute(savedKeystorePath)) {
-			savedKeystorePath = path.resolve(workspace.rootPath!, savedKeystorePath);
-		}
-		return savedKeystorePath;
-	} else if (lastUsed) {
-		return lastUsed;
-	}
-}
-
-export async function enterAndroidKeystoreInfo (lastUsed?: string, savedKeystorePath?: string): Promise<KeystoreInfo> {
-	const location = await selectAndroidKeystore(lastUsed, savedKeystorePath);
-
-	if (!location || !await pathExists(location)) {
-		throw new InteractionError(`The Keystore file ${location} does not exist`);
-	}
-	const alias = await inputBox({ placeHolder: 'Enter your keystore alias', value: ExtensionContainer.config.android.keystoreAlias || '' });
-	const password = await enterPassword({ placeHolder: 'Enter your keystore password' });
-	const privateKeyPassword = await enterPassword({ placeHolder: 'Enter your keystore private key password (optional)' });
-
-	return {
-		alias,
-		location,
-		password,
-		privateKeyPassword
-	};
-}
-
-export function selectiOSCertificate (buildType: string): Promise<CustomQuickPick> {
-	const certificateType: IosCertificateType = buildType === 'run' ? IosCertificateType.developer : IosCertificateType.distribution;
-	const certificates = appc.iOSCertificates(certificateType).map(cert => ({
-		description: `Expires: ${new Date(cert.after).toLocaleString('en-US')}`,
-		label: cert.fullname,
-		pem: cert.pem,
-		id: cert.fullname
-	}));
-	return quickPick(certificates, { placeHolder: 'Select certificate' });
-}
-
-export function selectiOSProvisioningProfile (certificate: any, target: string, appId: string): Promise<CustomQuickPick> {
-	let deployment = 'development';
-	if (target === 'dist-adhoc') {
-		deployment = 'distribution';
-	} else if (target === 'dist-appstore') {
-		deployment = 'appstore';
-	}
-	const profiles = appc.iOSProvisioningProfiles(deployment, certificate, appId).map(({ expirationDate, name, uuid }) => ({
-		description: uuid,
-		detail: `Expires: ${new Date(expirationDate).toLocaleString('en-US')}`,
-		label: name,
-		uuid,
-		id: uuid
-	}));
-	return quickPick(profiles, { placeHolder: 'Select provisioning profile' });
-}
-
-export async function selectiOSCodeSigning (buildType: string, target: string, appId: string): Promise<{ certificate: CustomQuickPick; provisioningProfile: CustomQuickPick & { uuid: string } }> {
-	const certificate = await selectiOSCertificate(buildType);
-
-	const provisioningProfile = await selectiOSProvisioningProfile(certificate, target, appId) as CustomQuickPick & { uuid: string };
-	return {
-		certificate,
-		provisioningProfile
-	};
-}
-
-export function selectiOSDevice (): Promise<CustomQuickPick & { udid: string }> {
-	const devices = appc.iOSDevices().map(device => ({ id: device.udid, label: device.name, udid: device.udid }));
-	return quickPick(devices, { placeHolder: 'Select device' }) as Promise<CustomQuickPick & { udid: string }>;
-}
-
-export function selectiOSSimulatorVersion (): Promise<CustomQuickPick> {
-	const versions = appc.iOSSimulatorVersions().map(version => ({ id: version, label: version }));
-	return quickPick(versions, { placeHolder: 'Select simulator version' });
-}
-
-export async function selectiOSSimulator (iOSVersion?: string): Promise<CustomQuickPick & { udid: string }> {
-	if (!iOSVersion) {
-		iOSVersion = (await selectiOSSimulatorVersion()).label; // eslint-disable-line require-atomic-updates
-	}
-	if (!appc.iOSSimulatorVersions().includes(iOSVersion)) {
-		throw new Error(`iOS Version ${iOSVersion} does not exist`);
-	}
-	const simulators = appc.iOSSimulators()[iOSVersion].map(({ name, udid }) => ({ label: `${name} (${iOSVersion})`, id: udid, udid, version: iOSVersion }));
-	return quickPick(simulators, { placeHolder: 'Select simulator' }) as Promise<CustomQuickPick & { udid: string }>;
-}
-
 export async function selectUpdates (updates: UpdateInfo[]): Promise<UpdateChoice[]> {
 	const choices: UpdateChoice[] = updates
 		.map(update => ({
@@ -303,19 +148,4 @@ export async function selectUpdates (updates: UpdateInfo[]): Promise<UpdateChoic
 	}
 
 	return choices as UpdateChoice[];
-}
-
-export async function selectDevice (platform: string, target: string): Promise<CustomQuickPick> {
-	if (platform === 'android' && target === 'emulator') {
-		return selectAndroidEmulator();
-	} else if (platform === 'android' && target === 'device') {
-		return selectAndroidDevice();
-	} else if (platform === 'ios' && target === 'device') {
-		return selectiOSDevice();
-	} else if (platform === 'ios' && target === 'simulator') {
-		const simVersion = await selectiOSSimulatorVersion();
-		return selectiOSSimulator(simVersion.label);
-	} else {
-		throw new Error(`Unsupported platform and combination target ${platform} + ${target}`);
-	}
 }

--- a/src/tasks/buildTaskProvider.ts
+++ b/src/tasks/buildTaskProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { CommandTaskProvider, TitaniumTaskBase, TitaniumTaskDefinitionBase, TitaniumBuildBase } from './commandTaskProvider';
-import { selectBuildTarget } from '../quickpicks/common';
+import { selectBuildTarget } from '../quickpicks/build/common';
 import { TaskExecutionContext, Platform, debugSessionInformation, DEBUG_SESSION_VALUE } from './tasksHelper';
 import { Helpers } from './helpers/';
 import { platforms } from '../utils';

--- a/src/tasks/helpers/android.ts
+++ b/src/tasks/helpers/android.ts
@@ -1,7 +1,8 @@
 import { TaskExecutionContext, runningTasks } from '../tasksHelper';
 import { TaskHelper } from './base';
 import { CommandBuilder } from '../commandBuilder';
-import { selectAndroidDevice, selectAndroidEmulator, selectAndroidKeystore, inputBox, enterPassword } from '../../quickpicks/common';
+import { selectAndroidDevice, selectAndroidEmulator, selectAndroidKeystore } from '../../quickpicks/build/android';
+import { inputBox, enterPassword } from '../../quickpicks/common';
 import { KeystoreInfo } from '../../types/common';
 import * as fs from 'fs-extra';
 import { AppBuildTaskTitaniumBuildBase, BuildTaskDefinitionBase, BuildTaskTitaniumBuildBase } from '../buildTaskProvider';

--- a/src/tasks/helpers/android.ts
+++ b/src/tasks/helpers/android.ts
@@ -1,7 +1,7 @@
 import { TaskExecutionContext, runningTasks } from '../tasksHelper';
 import { TaskHelper } from './base';
 import { CommandBuilder } from '../commandBuilder';
-import { selectAndroidDevice, selectAndroidEmulator, selectAndroidKeystore } from '../../quickpicks/build/android';
+import { selectAndroidKeystore } from '../../quickpicks/build/android';
 import { inputBox, enterPassword } from '../../quickpicks/common';
 import { KeystoreInfo } from '../../types/common';
 import * as fs from 'fs-extra';
@@ -60,21 +60,7 @@ export class AndroidHelper extends TaskHelper {
 	public async resolveAppBuildCommandLine (context: TaskExecutionContext, definition: AndroidBuildTaskTitaniumBuildBase): Promise<string> {
 		const builder = CommandBuilder.create('appc', 'run');
 
-		this.resolveCommonAppOptions(context, definition, builder);
-
-		if (!definition.deviceId) {
-			if (definition.target === 'device') {
-				const deviceInfo = await selectAndroidDevice();
-				definition.deviceId = deviceInfo.udid;
-			} else if (definition.target === 'emulator') {
-				const emulatorInfo = await selectAndroidEmulator();
-				definition.deviceId = emulatorInfo.udid;
-			} else {
-				throw new Error(`Invalid build target ${definition.target}`);
-			}
-		}
-
-		builder.addOption('--device-id', definition.deviceId);
+		await this.resolveCommonAppOptions(context, definition, builder);
 
 		if (definition.debugPort || definition.debug) {
 			builder.addOption('--debug-host', `/localhost:${definition.debugPort || '9000'}`);

--- a/src/tasks/helpers/ios.ts
+++ b/src/tasks/helpers/ios.ts
@@ -1,5 +1,5 @@
 import { TaskExecutionContext, runningTasks } from '../tasksHelper';
-import { selectiOSDevice, selectiOSSimulator, selectiOSCertificate } from '../../quickpicks';
+import { selectiOSDevice, selectiOSSimulator, selectiOSCertificate, selectiOSProvisioningProfile } from '../../quickpicks/build/ios';
 import { getCorrectCertificateName } from '../../utils';
 import project from '../../project';
 import { IosCertificateType, IosCert } from '../../types/common';
@@ -10,7 +10,6 @@ import { AppPackageTaskTitaniumBuildBase, PackageTaskDefinitionBase, PackageTask
 import { WorkspaceState } from '../../constants';
 
 import appc from '../../appc';
-import { selectiOSProvisioningProfile } from '../../quickpicks/common';
 
 export interface IosTitaniumBuildDefinition extends BuildTaskDefinitionBase {
 	titaniumBuild: IosBuildTaskTitaniumBuildBase;

--- a/src/tasks/helpers/ios.ts
+++ b/src/tasks/helpers/ios.ts
@@ -1,5 +1,5 @@
 import { TaskExecutionContext, runningTasks } from '../tasksHelper';
-import { selectiOSDevice, selectiOSSimulator, selectiOSCertificate, selectiOSProvisioningProfile } from '../../quickpicks/build/ios';
+import { selectiOSCertificate, selectiOSProvisioningProfile } from '../../quickpicks/build/ios';
 import { getCorrectCertificateName } from '../../utils';
 import project from '../../project';
 import { IosCertificateType, IosCert } from '../../types/common';
@@ -42,21 +42,7 @@ export class IosHelper extends TaskHelper {
 	public async resolveAppBuildCommandLine (context: TaskExecutionContext, definition: IosBuildTaskTitaniumBuildBase): Promise<string> {
 		const builder = CommandBuilder.create('appc', 'run');
 
-		this.resolveCommonAppOptions(context, definition, builder);
-
-		if (!definition.deviceId) {
-			if (definition.target === 'device') {
-				const deviceInfo = await selectiOSDevice();
-				definition.deviceId = deviceInfo.udid;
-			} else if (definition.target === 'simulator') {
-				const simulatorInfo = await selectiOSSimulator(definition.ios?.simulatorVersion);
-				definition.deviceId = simulatorInfo.udid;
-			} else {
-				throw new Error(`Invalid build target ${definition.target}`);
-			}
-		}
-
-		builder.addOption('--device-id', definition.deviceId);
+		await this.resolveCommonAppOptions(context, definition, builder);
 
 		if (definition.target === 'device') {
 			const iosInfo = definition.ios || {};

--- a/src/tasks/packageTaskProvider.ts
+++ b/src/tasks/packageTaskProvider.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { CommandTaskProvider, TitaniumTaskBase, TitaniumTaskDefinitionBase, TitaniumBuildBase } from './commandTaskProvider';
 import { Helpers } from './helpers';
 import { TaskExecutionContext } from './tasksHelper';
-import { selectDistributionTarget } from '../quickpicks';
+import { selectDistributionTarget } from '../quickpicks/build/common';
 
 export interface PackageTask extends TitaniumTaskBase {
 	definition: PackageTaskDefinitionBase;


### PR DESCRIPTION
* Splits out the build quickpicks into separate files in the hopes of reducing the chonky `quickpicks/common.ts` file down
* Adds a `Refresh Devices` option to the device list that will trigger and wait for the refresh explorer command to run before re-prompting
* Moves the common tasks code to use `selectDevices` instead of each platform handling their own device selection