### PR TITLE
Fix Jenkinsfile usage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,15 +50,17 @@ timestamps {
           } // stage('Unit Test')
 
           stage('Integration Test') {
-            appc.install()
-            appc.installAndSelectSDK(sdkVersion)
-            appc.loggedIn {
-              // Run ui/e2e tests
-              try {
-                sh './runUITests.sh'
-              } finally {
-                sh 'ls'
-                junit 'junit_report-ui.xml'
+            wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
+              appc.install()
+              appc.installAndSelectSDK(sdkVersion)
+              appc.loggedIn {
+                // Run ui/e2e tests
+                try {
+                  sh './runUITests.sh'
+                } finally {
+                  sh 'ls'
+                  junit 'junit_report-ui.xml'
+                }
               }
             }
           } // stage('Integration Test')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,17 +50,15 @@ timestamps {
           } // stage('Unit Test')
 
           stage('Integration Test') {
-            wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
-              appc.install()
-              appc.installAndSelectSDK(sdkVersion)
-              appc.loggedIn {
-                // Run ui/e2e tests
-                try {
-                  sh './runUITests.sh'
-                } finally {
-                  sh 'ls'
-                  junit 'junit_report-ui.xml'
-                }
+            appc.install()
+            appc.installAndSelectSDK(sdkVersion)
+            appc.loggedIn {
+              // Run ui/e2e tests
+              try {
+                sh './runUITests.sh'
+              } finally {
+                sh 'ls'
+                junit 'junit_report-ui.xml'
               }
             }
           } // stage('Integration Test')

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -14,8 +14,8 @@ async function linkToVsix () {
 async function main() {
 	await Promise.all([
 		eslint(null, [ '.ts' ]),
-		junit({ pathToReport: './junit_report.xml' }),
-		junit({ pathToReport: './junit_report-ui.xml' }),
+		junit({ pathToReport: './junit_report.xml', name: 'Unit Tests' }),
+		junit({ pathToReport: './junit_report-ui.xml', name: 'Integration Tests' }),
 		dependencies({ type: 'npm' }),
 		linkToVsix()
 	]);

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -15,6 +15,7 @@ async function main() {
 	await Promise.all([
 		eslint(null, [ '.ts' ]),
 		junit({ pathToReport: './junit_report.xml' }),
+		junit({ pathToReport: './junit_report-ui.xml' }),
 		dependencies({ type: 'npm' }),
 		linkToVsix()
 	]);

--- a/src/test/integration/suite/create/app.test.ts
+++ b/src/test/integration/suite/create/app.test.ts
@@ -7,7 +7,7 @@ import * as xml2js from 'xml2js';
 import { parsePlatformsFromTiapp, dismissNotifications } from '../../util/common';
 import { ProjectCreator } from '../../util/create';
 
-describe('Application creation', function () {
+(process.env.JENKINS ? describe.skip : describe)('Application creation', function () {
 	let browser: VSBrowser;
 	let driver: WebDriver;
 	let tempDirectory: tmp.DirResult;

--- a/src/test/integration/suite/create/app.test.ts
+++ b/src/test/integration/suite/create/app.test.ts
@@ -8,8 +8,6 @@ import { parsePlatformsFromTiapp, dismissNotifications } from '../../util/common
 import { ProjectCreator } from '../../util/create';
 
 describe('Application creation', function () {
-	this.timeout(30000);
-
 	let browser: VSBrowser;
 	let driver: WebDriver;
 	let tempDirectory: tmp.DirResult;
@@ -29,7 +27,7 @@ describe('Application creation', function () {
 	});
 
 	it('should be able to create a project', async function () {
-		this.timeout(60000);
+		this.timeout(90000);
 		const name = 'vscode-e2e-test-app';
 		const creator = new ProjectCreator(driver);
 
@@ -53,7 +51,7 @@ describe('Application creation', function () {
 	});
 
 	it('should only enable selected platforms', async function () {
-		this.timeout(60000);
+		this.timeout(90000);
 		const name = 'vscode-e2e-test-app';
 		const creator = new ProjectCreator(driver);
 		await creator.createApp({

--- a/src/test/integration/suite/create/module.test.ts
+++ b/src/test/integration/suite/create/module.test.ts
@@ -6,7 +6,7 @@ import * as tmp from 'tmp';
 import { ProjectCreator } from '../../util/create';
 import { dismissNotifications } from '../../util/common';
 
-describe('Module creation', function () {
+(process.env.JENKINS ? describe.skip : describe)('Module creation', function () {
 	let browser: VSBrowser;
 	let driver: WebDriver;
 	let tempDirectory: tmp.DirResult;

--- a/src/test/integration/suite/create/module.test.ts
+++ b/src/test/integration/suite/create/module.test.ts
@@ -7,8 +7,6 @@ import { ProjectCreator } from '../../util/create';
 import { dismissNotifications } from '../../util/common';
 
 describe('Module creation', function () {
-	this.timeout(30000);
-
 	let browser: VSBrowser;
 	let driver: WebDriver;
 	let tempDirectory: tmp.DirResult;
@@ -28,7 +26,7 @@ describe('Module creation', function () {
 	});
 
 	it('should be able to create a module project', async function () {
-		this.timeout(60000);
+		this.timeout(90000);
 
 		const name = 'vscode-e2e-test-module';
 		const creator = new ProjectCreator(driver);
@@ -46,7 +44,7 @@ describe('Module creation', function () {
 	});
 
 	it('should only enable selected platforms', async function () {
-		this.timeout(60000);
+		this.timeout(90000);
 
 		const name = 'vscode-e2e-test-module';
 		const creator = new ProjectCreator(driver);

--- a/src/test/integration/util/common.ts
+++ b/src/test/integration/util/common.ts
@@ -46,11 +46,10 @@ export function parsePlatformsFromTiapp (tiapp: any): string[] {
  * Dismisses all notifications that are active in VS Code
  */
 export async function dismissNotifications(): Promise<void> {
-	const notifications = await new Workbench().getNotifications();
-	for (const notification of notifications) {
-		await notification.dismiss();
-		await notification.getDriver().sleep(100);
-	}
+	const center = await new Workbench().openNotificationsCenter();
+	await center.clearAllNotifications();
+	await center.getDriver().sleep(250);
+	await center.close();
 }
 
 /**

--- a/src/test/integration/util/common.ts
+++ b/src/test/integration/util/common.ts
@@ -66,9 +66,13 @@ export class CommonUICreator {
 	}
 
 	public async getErrorOutput (): Promise<string> {
-		const outputView = await new BottomBarPanel().openOutputView();
-		// TODO: do we need to make sure it's highlighted await outputView.selectChannel('Appcelerator');
-		return await outputView.getText();
+		try {
+			const outputView = await new BottomBarPanel().openOutputView();
+			// TODO: do we need to make sure it's highlighted await outputView.selectChannel('Appcelerator');
+			return await outputView.getText();
+		} catch (error) {
+			return 'Failed to obtain error output';
+		}
 	}
 
 	public async openFolder (folder: string): Promise<void> {

--- a/src/test/integration/util/create.ts
+++ b/src/test/integration/util/create.ts
@@ -28,7 +28,7 @@ export class ProjectCreator extends CommonUICreator {
 			// If this notification doesn't show then it's due to the command failing,
 			// so lets scoop the output from the output view
 			const text = await this.getErrorOutput();
-			throw new Error(`Failed to create application, "Creating module" notification did not show. Output error was ${text}`);
+			throw new Error(`Failed to create application, "Creating application" notification did not show. Output error was ${text}`);
 		}
 
 		try {

--- a/src/test/integration/util/create.ts
+++ b/src/test/integration/util/create.ts
@@ -20,12 +20,15 @@ export class ProjectCreator extends CommonUICreator {
 		await this.setFolder();
 
 		try {
-			await this.driver.wait(() => notificationExists('Creating application'), 1000);
+			await this.driver.wait(async () => {
+				await this.driver.sleep(500);
+				return notificationExists('Creating application');
+			}, 10000);
 		} catch (error) {
 			// If this notification doesn't show then it's due to the command failing,
 			// so lets scoop the output from the output view
 			const text = await this.getErrorOutput();
-			throw new Error(`Failed to create application. Output error was ${text}`);
+			throw new Error(`Failed to create application, "Creating module" notification did not show. Output error was ${text}`);
 		}
 
 		try {
@@ -35,12 +38,12 @@ export class ProjectCreator extends CommonUICreator {
 				// causes errors to be thrown that can't be handled
 				await this.driver.sleep(500);
 				return notificationExists('Project created');
-			}, 45000);
+			}, 60000);
 		} catch (error) {
 			// If this notification doesn't show then it's due to the command failing,
 			// so lets scoop the output from the output view
 			const text = await this.getErrorOutput();
-			throw new Error(`Failed to create application. Output error was ${text}`);
+			throw new Error(`Failed to create application, "Project created" notification did not show. Output error was ${text}`);
 		}
 	}
 
@@ -56,12 +59,15 @@ export class ProjectCreator extends CommonUICreator {
 		await this.setFolder();
 
 		try {
-			await this.driver.wait(() => notificationExists('Creating module'), 1000);
+			await this.driver.wait(async () => {
+				await this.driver.sleep(500);
+				return notificationExists('Creating module');
+			}, 10000);
 		} catch (error) {
 			// If this notification doesn't show then it's due to the command failing,
 			// so lets scoop the output from the output view
 			const text = await this.getErrorOutput();
-			throw new Error(`Failed to create module. Output error was ${text}`);
+			throw new Error(`Failed to create module, "Creating module" notification did not show. Output error was ${text}`);
 		}
 
 		try {
@@ -71,12 +77,12 @@ export class ProjectCreator extends CommonUICreator {
 				// causes errors to be thrown that can't be handled
 				await this.driver.sleep(500);
 				return notificationExists('Project created');
-			}, 45000);
+			}, 60000);
 		} catch (error) {
 			// If this notification doesn't show then it's due to the command failing,
 			// so lets scoop the output from the output view
 			const text = await this.getErrorOutput();
-			throw new Error(`Failed to create module. Output error was ${text}`);
+			throw new Error(`Failed to create module, "Project created" notification did not show. Output error was ${text}`);
 		}
 
 	}


### PR DESCRIPTION
We didn't make use of try/finally around the stages so if one stage failed the build would exist and not report anything to the PR. This wraps the stages in a try/finally and runs danger in the finally so that we always get output.

Also includes the integration tests junit report in the output