### PR TITLE
feat(explorer): always show run button, stop running build if clicked

### DIFF
--- a/package.json
+++ b/package.json
@@ -636,7 +636,7 @@
       "view/title": [
         {
           "command": "titanium.build.run",
-          "when": "view == titanium.view.buildExplorer && !titanium:build:running",
+          "when": "view == titanium.view.buildExplorer",
           "group": "navigation@2"
         },
         {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -40,3 +40,11 @@ export function parseXmlString (xmlString: string): Promise<unknown> {
 		});
 	});
 }
+
+export function sleep (time: number): Promise<void> {
+	return new Promise(resolve => {
+		setTimeout(() => {
+			resolve();
+		}, time);
+	});
+}

--- a/src/debugger/titaniumDebugAdapter.ts
+++ b/src/debugger/titaniumDebugAdapter.ts
@@ -1,6 +1,7 @@
 import { ProxyServer } from '@awam/remotedebug-ios-webkit-adapter';
 import { ChromeDebugAdapter, Crdp } from '@awam/vscode-chrome-debug-core';
 import * as got from 'got';
+import { sleep } from '../common/utils';
 import { URL } from 'url';
 import { Event } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
@@ -118,7 +119,7 @@ export class TitaniumDebugAdapter extends ChromeDebugAdapter {
 			throw Error(errorMessage);
 		}
 
-		await this.sleep(250);
+		await sleep(250);
 
 		let body;
 		try {
@@ -134,14 +135,6 @@ export class TitaniumDebugAdapter extends ChromeDebugAdapter {
 		}
 
 		return this.pollForApp(url, errorMessage, maxRetries, iteration + 1);
-	}
-
-	private sleep (time: number): Promise<void> {
-		return new Promise(resolve => {
-			setTimeout(() => {
-				resolve();
-			}, time);
-		});
 	}
 
 	private cleanup (): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,6 +53,7 @@ import { UpdateInfo } from 'titanium-editor-commons/updates';
 import { registerTaskProviders, debugSessionInformation, DEBUG_SESSION_VALUE } from './tasks/tasksHelper';
 import { registerDebugProvider } from './debugger/titaniumDebugHelper';
 import { executeAsTask } from './utils';
+import { sleep } from './common/utils';
 
 function activate (context: vscode.ExtensionContext): Promise<void> {
 
@@ -109,6 +110,7 @@ function activate (context: vscode.ExtensionContext): Promise<void> {
 		vscode.commands.registerCommand(Commands.Build, async node => {
 			if (await ExtensionContainer.context.globalState.get<boolean>(GlobalState.Running)) {
 				await vscode.commands.executeCommand(Commands.StopBuild);
+				await sleep(100);
 			}
 			if (project.isTitaniumApp) {
 				return buildApplication(node);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,7 +106,10 @@ function activate (context: vscode.ExtensionContext): Promise<void> {
 		vscode.commands.registerCommand('titanium.init', init),
 
 		// register run command
-		vscode.commands.registerCommand(Commands.Build, node => {
+		vscode.commands.registerCommand(Commands.Build, async node => {
+			if (await ExtensionContainer.context.globalState.get<boolean>(GlobalState.Running)) {
+				await vscode.commands.executeCommand(Commands.StopBuild);
+			}
 			if (project.isTitaniumApp) {
 				return buildApplication(node);
 			} else if (project.isTitaniumModule) {


### PR DESCRIPTION
Rather than hiding the run button if a build is currently active, it will now always show and when
clicked it will cancel the running build and begin the flow for a new build to occur

Closes #436