### PR TITLE
feat(creation/module): support selecting android and ios codebase

### DIFF
--- a/src/commands/createModule.ts
+++ b/src/commands/createModule.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { commands, ProgressLocation, Uri, window } from 'vscode';
 import { VSCodeCommands, WorkspaceState } from '../constants';
 import { ExtensionContainer } from '../container';
-import { inputBox, selectCreationLocation, selectPlatforms, yesNoQuestion } from '../quickpicks';
+import { inputBox, selectCodeBases, selectCreationLocation, selectPlatforms, yesNoQuestion } from '../quickpicks';
 import { createModuleArguments, validateAppId } from '../utils';
 import { checkLogin, handleInteractionError, InteractionError } from './common';
 
@@ -27,6 +27,7 @@ export async function createModule (): Promise<void> {
 		});
 		const platforms = await selectPlatforms();
 		const workspaceDir = await selectCreationLocation(lastCreationPath);
+		const codeBases = await selectCodeBases(platforms);
 		ExtensionContainer.context.workspaceState.update(WorkspaceState.LastCreationPath, workspaceDir.fsPath);
 		if (await fs.pathExists(path.join(workspaceDir.fsPath, name))) {
 			force = await yesNoQuestion({ placeHolder: 'That module already exists. Would you like to overwrite?' }, true);
@@ -39,6 +40,7 @@ export async function createModule (): Promise<void> {
 			name,
 			platforms,
 			workspaceDir: workspaceDir.fsPath,
+			codeBases
 		});
 		await ExtensionContainer.terminal.runCommandInBackground(args, { cancellable: false, location: ProgressLocation.Notification, title: 'Creating module' });
 		// TODO: Once workspace support is figured out, add an "add to workspace command"

--- a/src/commands/createModule.ts
+++ b/src/commands/createModule.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import Appc from '../appc';
 
 import { commands, ProgressLocation, Uri, window } from 'vscode';
 import { VSCodeCommands, WorkspaceState } from '../constants';
@@ -7,10 +8,16 @@ import { ExtensionContainer } from '../container';
 import { inputBox, selectCodeBases, selectCreationLocation, selectPlatforms, yesNoQuestion } from '../quickpicks';
 import { createModuleArguments, validateAppId } from '../utils';
 import { checkLogin, handleInteractionError, InteractionError } from './common';
+import { promisify } from 'util';
 
 export async function createModule (): Promise<void> {
 	try {
 		checkLogin();
+
+		// force a refresh of the environment information to make sure that we have the correct
+		// selected SDK and CLI
+		await promisify(Appc.getInfo).bind(Appc)();
+
 		let force = false;
 		const logLevel = ExtensionContainer.config.general.logLevel;
 		const lastCreationPath = ExtensionContainer.context.workspaceState.get<string>(WorkspaceState.LastCreationPath);

--- a/src/quickpicks/creation.ts
+++ b/src/quickpicks/creation.ts
@@ -3,7 +3,6 @@ import Appc from '../appc';
 import { nameForPlatform, platforms } from '../utils';
 import { CustomQuickPick, quickPick } from './common';
 import { appc } from 'titanium-editor-commons/updates';
-import { promisify } from 'util';
 
 export interface CodeBase {
 	android?: 'java' | 'kotlin'
@@ -29,10 +28,6 @@ export async function selectCodeBases(platforms: string[]): Promise<CodeBase|und
 		android: undefined,
 		ios: undefined
 	};
-
-	if (!Appc.info) {
-		await promisify(Appc.getInfo).bind(Appc)();
-	}
 
 	const selectedSdk = Appc.selectedSdk();
 

--- a/src/quickpicks/creation.ts
+++ b/src/quickpicks/creation.ts
@@ -1,8 +1,65 @@
+import * as semver from 'semver';
+import Appc from '../appc';
 import { nameForPlatform, platforms } from '../utils';
 import { CustomQuickPick, quickPick } from './common';
+import { appc } from 'titanium-editor-commons/updates';
+
+export interface CodeBase {
+	android?: 'java' | 'kotlin'
+	ios?: 'objc' | 'swift'
+}
+
+interface AndroidCodeBaseQuickPickItem extends CustomQuickPick {
+	id: 'java' | 'kotlin'
+}
+
+interface iOSCodeBaseQuickPickItem extends CustomQuickPick {
+	id: 'objc' | 'swift'
+}
 
 export async function selectPlatforms (): Promise<string[]> {
 	const choices: CustomQuickPick[] = platforms().map(platform => ({ label: nameForPlatform(platform), id: platform, picked: true }));
 	const selected = await quickPick(choices, { canPickMany: true, placeHolder: 'Choose platforms' });
 	return selected.map((platform: CustomQuickPick)  => platform.id);
+}
+
+export async function selectCodeBases(platforms: string[]): Promise<CodeBase|undefined> {
+	const codeBases: CodeBase = {
+		android: undefined,
+		ios: undefined
+	};
+
+	const selectedSdk = Appc.selectedSdk();
+
+	if (!selectedSdk) {
+		return undefined;
+	}
+
+	// Support for this was only added in SDK 9.1.0
+	if (semver.lt(selectedSdk.version, '9.1.0')) {
+		return undefined;
+	}
+
+	// CLI 8.1.1 did not correctly handle the --ios-code-base option, so only ask for codebase
+	// options if they're using 8.1.1 or above
+	const selectedCLI = await appc.core.checkInstalledVersion();
+
+	if (!selectedCLI) {
+		return;
+	}
+
+	if (semver.lt(selectedCLI, '8.1.1')) {
+		return undefined;
+	}
+
+	if (platforms.includes('android')) {
+		codeBases.android = (await quickPick<AndroidCodeBaseQuickPickItem>([ { id: 'java', label: 'Java' }, { id: 'kotlin', label: 'Kotlin' } ], { canPickMany: false, placeHolder: 'Select Android codebase' })).id;
+	}
+
+	if (platforms.includes('ios')) {
+		codeBases.ios = (await quickPick<iOSCodeBaseQuickPickItem>([ { id: 'objc', label: 'Objective-C' }, { id: 'swift', label: 'Swift' } ], { canPickMany: false, placeHolder: 'Select iOS codebase' })).id;
+
+	}
+
+	return codeBases;
 }

--- a/src/quickpicks/creation.ts
+++ b/src/quickpicks/creation.ts
@@ -3,6 +3,7 @@ import Appc from '../appc';
 import { nameForPlatform, platforms } from '../utils';
 import { CustomQuickPick, quickPick } from './common';
 import { appc } from 'titanium-editor-commons/updates';
+import { promisify } from 'util';
 
 export interface CodeBase {
 	android?: 'java' | 'kotlin'
@@ -28,6 +29,10 @@ export async function selectCodeBases(platforms: string[]): Promise<CodeBase|und
 		android: undefined,
 		ios: undefined
 	};
+
+	if (!Appc.info) {
+		await promisify(Appc.getInfo).bind(Appc)();
+	}
 
 	const selectedSdk = Appc.selectedSdk();
 

--- a/src/test/integration/suite/create/module.test.ts
+++ b/src/test/integration/suite/create/module.test.ts
@@ -34,7 +34,11 @@ import { dismissNotifications } from '../../util/common';
 			id: 'com.axway.e2e',
 			folder: tempDirectory.name,
 			name,
-			platforms: [ 'android', 'ios' ]
+			platforms: [ 'android', 'ios' ],
+			codeBases: {
+				android: 'kotlin',
+				ios: 'swift'
+			}
 		});
 
 		const projectPath = path.join(tempDirectory.name, name);
@@ -53,7 +57,10 @@ import { dismissNotifications } from '../../util/common';
 			id: 'com.axway.e2e',
 			folder: tempDirectory.name,
 			name,
-			platforms: [ 'android' ]
+			platforms: [ 'android' ],
+			codeBases: {
+				android: 'kotlin'
+			}
 		});
 
 		const projectPath = path.join(tempDirectory.name, name);

--- a/src/test/integration/types.ts
+++ b/src/test/integration/types.ts
@@ -18,4 +18,8 @@ export type ModuleCreateOptions = {
 	folder: string;
 	name: string;
 	platforms: string[];
+	codeBases: {
+		android?: 'java' | 'kotlin';
+		ios?: 'objc' | 'swift';
+	}
 }

--- a/src/test/integration/util/create.ts
+++ b/src/test/integration/util/create.ts
@@ -59,6 +59,15 @@ export class ProjectCreator extends CommonUICreator {
 		await this.setPlatforms(options.platforms);
 		await this.setFolder();
 
+		// These come alphabetically
+		if (options.platforms.includes('android')) {
+			await this.setCodeBase('Android', options.codeBases.android || 'java');
+		}
+
+		if (options.platforms.includes('ios')) {
+			await this.setCodeBase('iOS', options.codeBases.ios || 'objc');
+		}
+
 		try {
 			await this.driver.wait(async () => {
 				await this.driver.sleep(500);
@@ -145,5 +154,16 @@ export class ProjectCreator extends CommonUICreator {
 			}
 		}
 		await input.confirm();
+	}
+
+	public async setCodeBase(platform: string, codeBase: string): Promise<void> {
+		const input = await InputBox.create();
+
+		const placeHolderText = await input.getPlaceHolder();
+		expect(placeHolderText).to.equal(`Select ${platform} codebase`, `Did not show ${platform} codebase selection`);
+
+		await input.setText(codeBase);
+		await input.confirm();
+		await this.driver.sleep(100);
 	}
 }

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -1,5 +1,6 @@
 import { KeystoreInfo, LogLevel, Platform as PlatformEnum  } from './common';
 import { Platform } from '../tasks/tasksHelper';
+import { CodeBase } from '../quickpicks/creation';
 
 export interface BaseCLIOptions {
 	logLevel: LogLevel;
@@ -72,6 +73,7 @@ export interface CreateAppOptions extends CreateOptions {
 
 export interface CreateModuleOptions extends CreateOptions {
 	codeBase?: 'swift' | 'objc';
+	codeBases?: CodeBase
 }
 
 export interface CleanAppOptions extends BaseCLIOptions {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -314,6 +314,14 @@ export function createModuleArguments (options: CreateModuleOptions): string[] {
 		'--log-level', options.logLevel
 	];
 
+	if (options.codeBases?.android) {
+		args.push('--android-code-base', options.codeBases.android);
+	}
+
+	if (options.codeBases?.ios) {
+		args.push('--ios-code-base', options.codeBases.ios);
+	}
+
 	if (options.force) {
 		args.push('--force');
 	}


### PR DESCRIPTION
If the selected SDK is >= 9.1.0 and the CLI is >= 8.1.1 then prompt for the code base to be used for the module

Closes [EDITOR-65](https://jira.appcelerator.org/browse/EDITOR-65)