### PR TITLE
Improve handling of no environment information in build explorer

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,8 @@ export enum GlobalState {
 	Liveview = 'titanium:liveview',
 	Running = 'titanium:build:running',
 	LastUpdateCheck = 'titanium:update:lastCheck',
-	HasUpdates = 'titanium:update:hasUpdates'
+	HasUpdates = 'titanium:update:hasUpdates',
+	RefreshEnvironment = 'titanium:environment:refresh'
 }
 
 export enum WorkspaceState {

--- a/src/explorer/nodes/targetNode.ts
+++ b/src/explorer/nodes/targetNode.ts
@@ -7,6 +7,9 @@ import appc from '../../appc';
 import { Platform } from '../../types/common';
 import { targetForName } from '../../utils';
 import { DevelopmentTarget } from '../../types/cli';
+import { BlankNode } from '../nodes';
+import { ExtensionContainer } from '../../container';
+import { GlobalState } from '../../constants';
 
 export class TargetNode extends BaseNode {
 
@@ -22,8 +25,16 @@ export class TargetNode extends BaseNode {
 		this.targetId = targetForName(this.label) as DevelopmentTarget;
 	}
 
-	public getChildren (): Array<OSVerNode|DeviceNode> {
+	public getChildren (): Array<OSVerNode|DeviceNode|BlankNode> {
 		const devices = [];
+
+		// Check if we're refreshing the environment information currently and return early so that
+		// the child nodes of each target display the message
+		const refreshingEnvironment = ExtensionContainer.context.globalState.get<boolean>(GlobalState.RefreshEnvironment);
+		if (refreshingEnvironment) {
+			return [ new BlankNode('Refreshing environment') ];
+		}
+
 		if (this.platform === 'ios') {
 			switch (this.label) {
 				case 'Simulator':
@@ -60,6 +71,10 @@ export class TargetNode extends BaseNode {
 					}
 					break;
 			}
+		}
+
+		if (!devices.length) {
+			devices.push(new BlankNode(`No ${this.label.toLowerCase()} detected`));
 		}
 		return devices;
 	}

--- a/src/explorer/tiExplorer.ts
+++ b/src/explorer/tiExplorer.ts
@@ -17,6 +17,8 @@ export default class DeviceExplorer implements vscode.TreeDataProvider<BaseNode>
 	public async refresh (): Promise<void> {
 		return vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: 'Reading Appcelerator environment ...' }, () => {
 			return new Promise((resolve, reject) => {
+				// fire a change event so that the child nodes of targets display the refresh message
+				this._onDidChangeTreeData.fire();
 				appc.getInfo((error, info) => {
 					if (info) {
 						this._onDidChangeTreeData.fire();


### PR DESCRIPTION
[EDITOR-57](https://jira.appcelerator.org/browse/EDITOR-57)

* Updates the `appc.ts` environment function to use optional chaining to avoid an error being thrown when accessing `this.info` before we have completed reading the infor
* Updates the build explorer to explicitly handle the following:
** Show a `Refreshing environment` message when we're loading the data (first startup, or from clicking Refresh Devices)
** Show a `No $type detected` message if none of that type is detected.
* Cleans up some unused code in appc.ts