### PR TITLE
Support variable substitution in tasks

### DIFF
--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -164,8 +164,3 @@ Visual Studio Code allows tasks to declare dependencies to create what is known 
 	]
 }
 ```
-
-## Current Limitations
-
-* [Variable substitution](https://code.visualstudio.com/docs/editor/variables-reference) is unsupported.
-* File paths provided in the task configuration have to be full paths.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1930,9 +1930,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.41.0.tgz",
-      "integrity": "sha512-7SfeY5u9jgiELwxyLB3z7l6l/GbN9CqpCQGkcRlB7tKRFBxzbz2PoBfGrLxI1vRfUCIq5+hg5vtDHExwq5j3+A==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.49.0.tgz",
+      "integrity": "sha512-wfNQmLmm1VdMBr6iuNdprWmC1YdrgZ9dQzadv+l2eSjJlElOdJw8OTm4RU4oGTBcfvG6RZI2jOcppkdSS18mZw==",
       "dev": true
     },
     "@types/which": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/appcelerator/vscode-appcelerator-titanium.git"
   },
   "engines": {
-    "vscode": "^1.41.0",
+    "vscode": "^1.49.0",
     "node": ">=12.4.0"
   },
   "activationEvents": [
@@ -945,7 +945,7 @@
     "@types/underscore": "^1.10.24",
     "@types/tmp": "^0.2.0",
     "@types/uuid": "^3.4.7",
-    "@types/vscode": "1.41.0",
+    "@types/vscode": "1.49.0",
     "@types/which": "^1.3.2",
     "@types/xml2js": "^0.4.5",
     "@typescript-eslint/eslint-plugin": "^4.5.0",

--- a/src/explorer/tiExplorer.ts
+++ b/src/explorer/tiExplorer.ts
@@ -7,10 +7,10 @@ import { PlatformNode } from './nodes/platformNode';
 
 export default class DeviceExplorer implements vscode.TreeDataProvider<BaseNode> {
 
-	private _onDidChangeTreeData: vscode.EventEmitter<BaseNode> = new vscode.EventEmitter();
+	private _onDidChangeTreeData: vscode.EventEmitter<BaseNode|undefined> = new vscode.EventEmitter();
 
 	// tslint:disable-next-line member-ordering
-	public readonly onDidChangeTreeData: vscode.Event<BaseNode> = this._onDidChangeTreeData.event;
+	public readonly onDidChangeTreeData: vscode.Event<BaseNode|undefined> = this._onDidChangeTreeData.event;
 
 	private platforms: Map<string, PlatformNode> = new Map();
 
@@ -18,10 +18,10 @@ export default class DeviceExplorer implements vscode.TreeDataProvider<BaseNode>
 		return vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: 'Reading Appcelerator environment ...' }, () => {
 			return new Promise((resolve, reject) => {
 				// fire a change event so that the child nodes of targets display the refresh message
-				this._onDidChangeTreeData.fire();
+				this._onDidChangeTreeData.fire(undefined);
 				appc.getInfo((error, info) => {
 					if (info) {
-						this._onDidChangeTreeData.fire();
+						this._onDidChangeTreeData.fire(undefined);
 						vscode.window.showInformationMessage('Updated device explorer');
 						return resolve();
 					} else {

--- a/src/explorer/updatesExplorer.ts
+++ b/src/explorer/updatesExplorer.ts
@@ -11,10 +11,10 @@ export default class UpdateExplorer implements vscode.TreeDataProvider<BaseNode>
 
 	public updates: UpdateInfo[] = [];
 
-	private _onDidChangeTreeData: vscode.EventEmitter<BaseNode> = new vscode.EventEmitter();
+	private _onDidChangeTreeData: vscode.EventEmitter<BaseNode|undefined> = new vscode.EventEmitter();
 
 	// tslint:disable-next-line member-ordering
-	public readonly onDidChangeTreeData: vscode.Event<BaseNode> = this._onDidChangeTreeData.event;
+	public readonly onDidChangeTreeData: vscode.Event<BaseNode|undefined> = this._onDidChangeTreeData.event;
 
 	private updateMap: Map<string, UpdateNode> = new Map();
 
@@ -22,7 +22,7 @@ export default class UpdateExplorer implements vscode.TreeDataProvider<BaseNode>
 
 	public async refresh (): Promise<void> {
 		this.checkingForUpdates = true;
-		this._onDidChangeTreeData.fire();
+		this._onDidChangeTreeData.fire(undefined);
 		try {
 			const supportedVersions = await getNodeSupportedVersion(project.sdk()[0]);
 			this.updates = await updates.checkAllUpdates({ nodeJS: supportedVersions });
@@ -35,7 +35,7 @@ export default class UpdateExplorer implements vscode.TreeDataProvider<BaseNode>
 			await vscode.window.showErrorMessage(message);
 		}
 		this.checkingForUpdates = false;
-		this._onDidChangeTreeData.fire();
+		this._onDidChangeTreeData.fire(undefined);
 		if (this.updates.length) {
 			ExtensionContainer.context.globalState.update(GlobalState.HasUpdates, true);
 			vscode.commands.executeCommand('setContext', GlobalState.HasUpdates, true);

--- a/src/tasks/buildTaskProvider.ts
+++ b/src/tasks/buildTaskProvider.ts
@@ -148,7 +148,7 @@ export class BuildTaskProvider extends CommandTaskProvider {
 			task.isBackground = true;
 		}
 
-		task.execution = new vscode.CustomExecution(() => Promise.resolve(new TaskPseudoTerminal(this, task as TitaniumTaskBase)));
+		task.execution = new vscode.CustomExecution((resolvedDefinition) => Promise.resolve(new TaskPseudoTerminal(this, task as TitaniumTaskBase, resolvedDefinition as BuildTaskDefinitionBase)));
 
 		return task;
 	}

--- a/src/tasks/commandTaskProvider.ts
+++ b/src/tasks/commandTaskProvider.ts
@@ -51,7 +51,7 @@ export abstract class CommandTaskProvider implements vscode.TaskProvider {
 			task.scope || vscode.TaskScope.Workspace,
 			task.name,
 			task.source,
-			new vscode.CustomExecution(() => Promise.resolve(new TaskPseudoTerminal(this, task)))
+			new vscode.CustomExecution((resolvedDefinition) => Promise.resolve(new TaskPseudoTerminal(this, task, resolvedDefinition as TitaniumTaskDefinitionBase)))
 		);
 	}
 


### PR DESCRIPTION
This allows the usage of [VS Codes variables](https://code.visualstudio.com/docs/editor/variables-reference) in tasks. This is mostly useful for setting paths in properties such as `outputDirectory` in tasks that maybe used across machines e.g. `"outputDirectory": "${workspaceFolder}/dist",`

Closes [EDITOR-48](https://jira.appcelerator.org/browse/EDITOR-48)

Note: this will raise the minimum VS Code to 1.49.0 (August 2020)