### PR TITLE
Integration test improvements

### DIFF
--- a/src/test/integration/suite/alloy/generate.test.ts
+++ b/src/test/integration/suite/alloy/generate.test.ts
@@ -31,7 +31,9 @@ describe('Alloy component generation', function () {
 	});
 
 	afterEach(async function () {
-		await remove(tempDirectory.name);
+		if (tempDirectory) {
+			await remove(tempDirectory.name);
+		}
 	});
 
 	// alloy generate controller creates all 3 files

--- a/src/test/integration/suite/alloy/generate.test.ts
+++ b/src/test/integration/suite/alloy/generate.test.ts
@@ -27,6 +27,7 @@ describe('Alloy component generation', function () {
 		tempDirectory = tmp.dirSync();
 		await copy(projectDirectory, tempDirectory.name);
 		await generator.openFolder(tempDirectory.name);
+		await generator.waitForEnvironmentDetectionCompletion();
 	});
 
 	afterEach(async function () {

--- a/src/test/integration/suite/create/app.test.ts
+++ b/src/test/integration/suite/create/app.test.ts
@@ -8,9 +8,12 @@ import { parsePlatformsFromTiapp, dismissNotifications } from '../../util/common
 import { ProjectCreator } from '../../util/create';
 
 (process.env.JENKINS ? describe.skip : describe)('Application creation', function () {
+	this.timeout(30000);
+
 	let browser: VSBrowser;
 	let driver: WebDriver;
 	let tempDirectory: tmp.DirResult;
+	let creator: ProjectCreator;
 
 	beforeEach(async function () {
 		browser = VSBrowser.instance;
@@ -20,6 +23,8 @@ import { ProjectCreator } from '../../util/create';
 		await browser.waitForWorkbench();
 		tempDirectory = tmp.dirSync();
 		await dismissNotifications();
+		creator = new ProjectCreator(driver);
+		await creator.waitForEnvironmentDetectionCompletion();
 	});
 
 	afterEach(async function () {
@@ -29,7 +34,6 @@ import { ProjectCreator } from '../../util/create';
 	it('should be able to create a project', async function () {
 		this.timeout(90000);
 		const name = 'vscode-e2e-test-app';
-		const creator = new ProjectCreator(driver);
 
 		await creator.createApp({
 			id: 'com.axway.e2e',
@@ -53,7 +57,7 @@ import { ProjectCreator } from '../../util/create';
 	it('should only enable selected platforms', async function () {
 		this.timeout(90000);
 		const name = 'vscode-e2e-test-app';
-		const creator = new ProjectCreator(driver);
+
 		await creator.createApp({
 			id: 'com.axway.e2e',
 			enableServices: false,

--- a/src/test/integration/suite/create/app.test.ts
+++ b/src/test/integration/suite/create/app.test.ts
@@ -28,7 +28,9 @@ import { ProjectCreator } from '../../util/create';
 	});
 
 	afterEach(async function () {
-		await fs.remove(tempDirectory.name);
+		if (tempDirectory) {
+			await fs.remove(tempDirectory.name);
+		}
 	});
 
 	it('should be able to create a project', async function () {

--- a/src/test/integration/suite/create/module.test.ts
+++ b/src/test/integration/suite/create/module.test.ts
@@ -27,7 +27,9 @@ import { dismissNotifications } from '../../util/common';
 	});
 
 	afterEach(async function () {
-		await fs.remove(tempDirectory.name);
+		if (tempDirectory) {
+			await fs.remove(tempDirectory.name);
+		}
 	});
 
 	it('should be able to create a module project', async function () {

--- a/src/test/integration/suite/create/module.test.ts
+++ b/src/test/integration/suite/create/module.test.ts
@@ -7,7 +7,10 @@ import { ProjectCreator } from '../../util/create';
 import { dismissNotifications } from '../../util/common';
 
 (process.env.JENKINS ? describe.skip : describe)('Module creation', function () {
+	this.timeout(30000);
+
 	let browser: VSBrowser;
+	let creator: ProjectCreator;
 	let driver: WebDriver;
 	let tempDirectory: tmp.DirResult;
 
@@ -19,6 +22,8 @@ import { dismissNotifications } from '../../util/common';
 		await browser.waitForWorkbench();
 		tempDirectory = tmp.dirSync();
 		await dismissNotifications();
+		creator = new ProjectCreator(driver);
+		await creator.waitForEnvironmentDetectionCompletion();
 	});
 
 	afterEach(async function () {
@@ -29,7 +34,7 @@ import { dismissNotifications } from '../../util/common';
 		this.timeout(90000);
 
 		const name = 'vscode-e2e-test-module';
-		const creator = new ProjectCreator(driver);
+
 		await creator.createModule({
 			id: 'com.axway.e2e',
 			folder: tempDirectory.name,
@@ -51,7 +56,6 @@ import { dismissNotifications } from '../../util/common';
 		this.timeout(90000);
 
 		const name = 'vscode-e2e-test-module';
-		const creator = new ProjectCreator(driver);
 
 		await creator.createModule({
 			id: 'com.axway.e2e',

--- a/src/test/integration/util/common.ts
+++ b/src/test/integration/util/common.ts
@@ -92,6 +92,21 @@ export class CommonUICreator {
 		const setting = await editor.findSetting(settingName, `Titanium › ${section}`) as TextSetting;
 		await setting.setValue(value);
 	}
+
+	public async waitForEnvironmentDetectionCompletion(): Promise<void> {
+		let exists = true;
+		while (exists) {
+			// do nothing
+			const notification = await notificationExists('Validating Environment');
+			if (!notification) {
+				exists = false;
+			} else {
+				console.log('notification exists');
+				console.log(notification);
+			}
+		}
+		return;
+	}
 }
 
 /**

--- a/src/test/integration/util/create.ts
+++ b/src/test/integration/util/create.ts
@@ -54,6 +54,10 @@ export class ProjectCreator extends CommonUICreator {
 
 		await this.workbench.executeCommand('Titanium: Create module');
 
+		// HACK: Need to figure out a better way to wait for the environment detection to finish,
+		// maybe we should just have a notification for it?
+		await this.driver.sleep(10000);
+
 		await this.setName(options.name);
 		await this.setId(options.id);
 		await this.setPlatforms(options.platforms);


### PR DESCRIPTION
* Contains a hack to sleep while the `Appc.getInfo` call in the create module flow finishes
* Adds a wait in the `beforeEach` of each test for the environment detection to finish
* Only removes the tempDirectory if we created one as sometimes the test setup can barf before we get to creating it