### PR TITLE
fix(tasks/build): check cancellation status before closing terminal

### DIFF
--- a/scripts/templates/tasks.md.ejs
+++ b/scripts/templates/tasks.md.ejs
@@ -173,8 +173,3 @@ Visual Studio Code allows tasks to declare dependencies to create what is known 
 	]
 }
 ```
-
-## Current Limitations
-
-* [Variable substitution](https://code.visualstudio.com/docs/editor/variables-reference) is unsupported.
-* File paths provided in the task configuration have to be full paths.

--- a/src/tasks/taskPseudoTerminal.ts
+++ b/src/tasks/taskPseudoTerminal.ts
@@ -108,6 +108,9 @@ export class TaskPseudoTerminal implements vscode.Pseudoterminal {
 	}
 
 	public close (code?: number): void {
+		if (this.cts.token.isCancellationRequested) {
+			return;
+		}
 		this.cts.cancel();
 		this.closeEmitter.fire(code || 0);
 		ExtensionContainer.context.globalState.update(GlobalState.Running, false);


### PR DESCRIPTION
close is be called twice, once when terminate is called from StopBuild and then a second time when
from the close event listener on our subprocess. By checking the cancellation token status we avoid
rerunning the close code twice which can put us into an invalid state if we're performing a rebuild

Also removes the limitations note from the ejs template for tasks as I forgot to remove it from there before

To reproduce, click the play button on a device in the device treeview multiple times. It should start new builds with no problems