### PR TITLE
feat: surface error from environment detection if one occurs

### DIFF
--- a/src/commands/createModule.ts
+++ b/src/commands/createModule.ts
@@ -8,7 +8,6 @@ import { ExtensionContainer } from '../container';
 import { inputBox, selectCodeBases, selectCreationLocation, selectPlatforms, yesNoQuestion } from '../quickpicks';
 import { createModuleArguments, validateAppId } from '../utils';
 import { checkLogin, handleInteractionError, InteractionError } from './common';
-import { promisify } from 'util';
 
 export async function createModule (): Promise<void> {
 	try {
@@ -16,7 +15,7 @@ export async function createModule (): Promise<void> {
 
 		// force a refresh of the environment information to make sure that we have the correct
 		// selected SDK and CLI
-		await promisify(Appc.getInfo).bind(Appc)();
+		await Appc.getInfo();
 
 		let force = false;
 		const logLevel = ExtensionContainer.config.general.logLevel;

--- a/src/explorer/tiExplorer.ts
+++ b/src/explorer/tiExplorer.ts
@@ -15,21 +15,18 @@ export default class DeviceExplorer implements vscode.TreeDataProvider<BaseNode>
 	private platforms: Map<string, PlatformNode> = new Map();
 
 	public async refresh (): Promise<void> {
-		return vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: 'Reading Appcelerator environment ...' }, () => {
-			return new Promise((resolve, reject) => {
-				// fire a change event so that the child nodes of targets display the refresh message
+		return vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: 'Reading Appcelerator environment ...' }, async () => {
+			// fire a change event so that the child nodes of targets display the refresh message
+			this._onDidChangeTreeData.fire(undefined);
+			try {
+				await appc.getInfo();
 				this._onDidChangeTreeData.fire(undefined);
-				appc.getInfo((error, info) => {
-					if (info) {
-						this._onDidChangeTreeData.fire(undefined);
-						vscode.window.showInformationMessage('Updated device explorer');
-						return resolve();
-					} else {
-						vscode.window.showErrorMessage('Error fetching Appcelerator environment');
-						return reject();
-					}
-				});
-			});
+				vscode.window.showInformationMessage('Updated device explorer');
+				return Promise.resolve();
+			} catch (error) {
+				vscode.window.showErrorMessage('Error fetching Appcelerator environment');
+				return Promise.reject();
+			}
 		});
 	}
 


### PR DESCRIPTION
[EDITOR-72](https://jira.appcelerator.org/browse/EDITOR-72)

If the `appc ti info` command fails this will send the output of that command to a output channel and prompt the user to check it out, this hopefully might make it easier to debug issues like #484