### PR TITLE
Fix installing all updates instead of selected, fix issue with updates progress notification sticking around

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -164,8 +164,7 @@ export function registerCommands (): void {
 				}
 				vscode.commands.executeCommand(Commands.RefreshUpdates);
 				vscode.commands.executeCommand(Commands.RefreshExplorer);
-				await vscode.window.showInformationMessage(`Installed ${totalUpdates} ${totalUpdates > 1 ? 'updates' : 'update'}`);
-				return Promise.resolve();
+				vscode.window.showInformationMessage(`Installed ${totalUpdates} ${totalUpdates > 1 ? 'updates' : 'update'}`);
 			});
 		} catch (error) {
 			// TODO: add some sort of error reporting

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,8 +10,6 @@ import { ExtensionContainer } from './container';
 
 import { Config, Configuration, configuration } from './configuration';
 
-import * as definitionProviderHelper from './providers/definition/definitionProviderHelper';
-
 import { completion, environment, updates } from 'titanium-editor-commons';
 
 import { registerTaskProviders } from './tasks/tasksHelper';
@@ -31,7 +29,6 @@ function activate (context: vscode.ExtensionContext): Promise<void> {
 
 	ExtensionContainer.inititalize(context, config);
 	project.load();
-	definitionProviderHelper.activate(context);
 
 	if (!project.isTitaniumProject()) {
 		vscode.commands.executeCommand(VSCodeCommands.SetContext, GlobalState.Enabled, false);

--- a/src/providers/definition/definitionProviderHelper.ts
+++ b/src/providers/definition/definitionProviderHelper.ts
@@ -3,7 +3,7 @@ import * as walkSync from 'klaw-sync';
 import * as path from 'path';
 import * as utils from '../../utils';
 
-import { DefinitionLink, Hover, Location, MarkdownString, Position, Range, Selection, TextDocument, Uri, workspace, WorkspaceEdit, Definition, commands, ExtensionContext, Command } from 'vscode';
+import { DefinitionLink, Hover, Location, MarkdownString, Position, Range, Selection, TextDocument, Uri, workspace, WorkspaceEdit, Definition, Command } from 'vscode';
 import { ExtensionContainer } from '../../container';
 import { DefinitionSuggestion } from './common';
 
@@ -260,15 +260,4 @@ export async function insertI18nString (text: string): Promise<void> {
 		edit.insert(Uri.file(i18nStringPath), position, insertText);
 		workspace.applyEdit(edit);
 	}
-}
-
-/**
- * Register insert text command
- *
- * @param {Array} subscriptions disposables
- */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function activate(context: ExtensionContext) {
-	context.subscriptions.push(commands.registerCommand(insertCommandId, insert));
-	context.subscriptions.push(commands.registerCommand(insertI18nStringCommandId, insertI18nString));
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,9 +1,11 @@
+import { registerCommand } from '../commands';
 import * as vscode from 'vscode';
 import { ControllerCompletionItemProvider } from './completion/controllerCompletionItemProvider';
 import { StyleCompletionItemProvider } from './completion/styleCompletionItemProvider';
 import { TiappCompletionItemProvider } from './completion/tiappCompletionItemProvider';
 import { ViewCompletionItemProvider } from './completion/viewCompletionItemProvider';
 import { ControllerDefinitionProvider } from './definition/controllerDefinitionProvider';
+import { insert, insertCommandId, insertI18nString, insertI18nStringCommandId } from './definition/definitionProviderHelper';
 import { StyleDefinitionProvider } from './definition/styleDefinitionProvider';
 import { ViewCodeActionProvider } from './definition/viewCodeActionProvider';
 import { ViewDefinitionProvider } from './definition/viewDefinitionProvider';
@@ -39,4 +41,8 @@ export function registerProviders(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(
 		vscode.languages.registerCodeActionsProvider({ scheme: 'file', pattern: viewFilePattern }, new ViewCodeActionProvider())
 	);
+
+	// register code action commands
+	registerCommand(insertCommandId, insert);
+	registerCommand(insertI18nStringCommandId, insertI18nString);
 }

--- a/src/quickpicks/common.ts
+++ b/src/quickpicks/common.ts
@@ -52,10 +52,11 @@ export async function yesNoQuestion (options: QuickPickOptions, shouldThrow = fa
 	}
 }
 
-export async function quickPick(items: string[], quickPickOptions?: QuickPickOptions & { canPickMany: true }, customQuickPickOptions?: CustomQuickPickOptions): Promise<string[]>;
+export async function quickPick(items: string[], quickPickOptions: QuickPickOptions & { canPickMany: true }, customQuickPickOptions?: CustomQuickPickOptions): Promise<string[]>;
 export async function quickPick(items: CustomQuickPick[], quickPickOptions?: QuickPickOptions & { canPickMany: true }, customQuickPickOptions?: CustomQuickPickOptions): Promise<CustomQuickPick[]>;
 export async function quickPick(items: string[], quickPickOptions?: QuickPickOptions, customQuickPickOptions?: CustomQuickPickOptions): Promise<string>;
 export async function quickPick(items: CustomQuickPick[], quickPickOptions?: QuickPickOptions, customQuickPickOptions?: CustomQuickPickOptions): Promise<CustomQuickPick>;
+export async function quickPick<T extends CustomQuickPick>(items: T[], quickPickOptions: QuickPickOptions & { canPickMany: true }, customQuickPickOptions?: CustomQuickPickOptions): Promise<T[]>;
 export async function quickPick<T extends CustomQuickPick>(items: T[], quickPickOptions?: QuickPickOptions, customQuickPickOptions?: CustomQuickPickOptions): Promise<T>;
 export async function quickPick<T extends CustomQuickPick> (items: T[], quickPickOptions?: QuickPickOptions, { forceShow = false } = {}): Promise<T> {
 	if (items.length === 1 && !forceShow) {
@@ -142,7 +143,7 @@ export async function selectUpdates (updates: UpdateInfo[]): Promise<UpdateChoic
 		})
 		);
 
-	const selected = await quickPick(choices, {
+	const selected = await quickPick<UpdateChoice>(choices, {
 		canPickMany: true,
 		placeHolder: 'Which updates would you like to install?'
 	}, {
@@ -153,5 +154,5 @@ export async function selectUpdates (updates: UpdateInfo[]): Promise<UpdateChoic
 		throw new UserCancellation();
 	}
 
-	return choices as UpdateChoice[];
+	return selected;
 }


### PR DESCRIPTION
This PR fixes a couple issues I noticed with the updates flow, namely:

* We would ask the user to select updates, then install them all irregardless of what they asked
* The progress notification would stick around until the information message was dismissed. Now it disappears as soon as the flow is finished