### PR TITLE
Refactor update commands to reduce dupe code, refactor startup code to separate out different states

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,7 +15,9 @@ export enum GlobalState {
 	Running = 'titanium:build:running',
 	LastUpdateCheck = 'titanium:update:lastCheck',
 	HasUpdates = 'titanium:update:hasUpdates',
-	RefreshEnvironment = 'titanium:environment:refresh'
+	RefreshEnvironment = 'titanium:environment:refresh',
+	MissingTooling = 'titanium:toolingMissing',
+	NotTitaniumProject = 'titanium:notProject'
 }
 
 export enum WorkspaceState {

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,6 +1,7 @@
-import { ExtensionContext, TaskExecution } from 'vscode';
+import * as vscode from 'vscode';
 import appc, { Appc } from './appc';
 import { Config, configuration } from './configuration';
+import { GlobalState, VSCodeCommands } from './constants';
 import DeviceExplorer from './explorer/tiExplorer';
 import UpdateExplorer from './explorer/updateExplorer';
 import Terminal from './terminal';
@@ -9,12 +10,12 @@ export class ExtensionContainer {
 	private static _appc: Appc;
 	private static _buildExplorer: DeviceExplorer;
 	private static _config: Config | undefined;
-	private static _context: ExtensionContext;
-	private static _runningTask: TaskExecution|undefined;
+	private static _context: vscode.ExtensionContext;
+	private static _runningTask: vscode.TaskExecution|undefined;
 	private static _terminal: Terminal;
 	private static _updateExplorer: UpdateExplorer;
 
-	public static inititalize (context: ExtensionContext, config: Config): void {
+	public static inititalize (context: vscode.ExtensionContext, config: Config): void {
 		this._appc = appc;
 		this._config = config;
 		this._context = context;
@@ -31,7 +32,7 @@ export class ExtensionContainer {
 		return this._config;
 	}
 
-	static get context (): ExtensionContext {
+	static get context (): vscode.ExtensionContext {
 		return this._context;
 	}
 
@@ -46,11 +47,11 @@ export class ExtensionContainer {
 		this._config = undefined;
 	}
 
-	static set runningTask (task: TaskExecution|undefined) {
+	static set runningTask (task: vscode.TaskExecution|undefined) {
 		this._runningTask = task;
 	}
 
-	static get runningTask (): TaskExecution|undefined {
+	static get runningTask (): vscode.TaskExecution|undefined {
 		return this._runningTask;
 	}
 
@@ -68,5 +69,17 @@ export class ExtensionContainer {
 
 	static get updateExplorer (): UpdateExplorer {
 		return this._updateExplorer;
+	}
+
+	/**
+	 * Updates the property in both VS Code context, for when clauses used in the package.json, and
+	 * also the globalSate for the ExtensionContext
+	 *
+	 * @param {GlobalState} stateName - State value to change
+	 * @param {T} value - Value to be changed
+	 */
+	static setContext<T>(stateName: GlobalState, value: T): void {
+		vscode.commands.executeCommand(VSCodeCommands.SetContext, stateName, value);
+		ExtensionContainer.context.globalState.update(stateName, value);
 	}
 }

--- a/src/explorer/updateExplorer.ts
+++ b/src/explorer/updateExplorer.ts
@@ -9,7 +9,7 @@ import project from '../project';
 
 export default class UpdateExplorer implements vscode.TreeDataProvider<BaseNode> {
 
-	public updates: UpdateInfo[] = [];
+	public updates?: UpdateInfo[];
 
 	private _onDidChangeTreeData: vscode.EventEmitter<BaseNode|undefined> = new vscode.EventEmitter();
 
@@ -36,7 +36,7 @@ export default class UpdateExplorer implements vscode.TreeDataProvider<BaseNode>
 		}
 		this.checkingForUpdates = false;
 		this._onDidChangeTreeData.fire(undefined);
-		if (this.updates.length) {
+		if (this.updates?.length) {
 			ExtensionContainer.context.globalState.update(GlobalState.HasUpdates, true);
 			vscode.commands.executeCommand('setContext', GlobalState.HasUpdates, true);
 		}
@@ -46,13 +46,18 @@ export default class UpdateExplorer implements vscode.TreeDataProvider<BaseNode>
 		return element.getTreeItem(element);
 	}
 
-	public getChildren (): Promise<Array<BlankNode|UpdateNode>> {
+	public getChildren (): Array<BlankNode|UpdateNode> {
 
 		const elements = [];
 
 		if (this.checkingForUpdates) {
 			elements.push(new BlankNode('Checking for updates'));
-			return Promise.resolve(elements);
+			return elements;
+		}
+
+		if (!this.updates?.length) {
+			elements.push(new BlankNode('There are no updates available'));
+			return elements;
 		}
 
 		for (const update of this.updates) {
@@ -63,11 +68,7 @@ export default class UpdateExplorer implements vscode.TreeDataProvider<BaseNode>
 			elements.push(node);
 		}
 
-		if (!elements.length) {
-			elements.push(new BlankNode('There are no updates available'));
-		}
-
-		return Promise.resolve(elements);
+		return elements;
 	}
 
 }

--- a/src/updates/index.ts
+++ b/src/updates/index.ts
@@ -1,54 +1,75 @@
 import * as vscode from 'vscode';
 import { ProductNames, UpdateInfo } from 'titanium-editor-commons/updates';
-import { UpdateChoice } from '../types/common';
 import { executeAsTask } from '../utils';
+import { updates } from 'titanium-editor-commons';
+import { selectUpdates } from '../quickpicks/common';
+import { ExtensionContainer } from '../container';
+import { Commands } from '../commands';
+import { GlobalState } from '../constants';
 
-export async function installUpdates (updateInfo: UpdateChoice[] | UpdateInfo[], progress: vscode.Progress<{ message?: string, increment?: number }>, incrementProgress = true): Promise<void> {
-	const totalUpdates = updateInfo.length;
-	let counter = 1;
-
-	// sort prior to running
-	updateInfo.sort((curr: UpdateChoice|UpdateInfo, prev: UpdateChoice|UpdateInfo) => curr.priority - prev.priority);
-
-	for (const update of updateInfo) {
-		const label = (update as UpdateChoice).label || `${update.productName}: ${update.latestVersion}`;
-		progress.report({
-			message: `Installing ${label} (${counter}/${totalUpdates})`
-		});
-		try {
-			await update.action(update.latestVersion);
-			progress.report({
-				message: `Installed ${label} (${counter}/${totalUpdates})`
-			});
-			if (incrementProgress) {
-				progress.report({
-					increment: 100 / totalUpdates
-				});
-			}
-		} catch (error) {
-			progress.report({
-				message: `Failed to install ${label} (${counter}/${totalUpdates})`
-			});
-			if (incrementProgress) {
-				progress.report({
-					increment: 100 / totalUpdates
-				});
-			}
-			if (error.metadata) {
-				const { metadata } = error;
-				if ((update.productName === ProductNames.AppcInstaller || update.productName === ProductNames.Node) && metadata.errorCode === 'EACCES') {
-					const runWithSudo = await vscode.window.showErrorMessage(`Failed to update to ${label} as it must be ran with sudo`, {
-						title: 'Install with Sudo'
-					});
-					if (runWithSudo) {
-						await executeAsTask(`sudo ${metadata.command}`, update.productName);
-					}
-				}
-			} else {
-				// TODO should we show the error that we got passed?
-				await vscode.window.showErrorMessage(`Failed to update to ${label}`);
-			}
+export async function installUpdates (updateInfo?: UpdateInfo[], promptForChoice?: boolean): Promise<void> {
+	vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: 'Titanium Updates', cancellable: false }, async progress => {
+		if (!updateInfo) {
+			progress.report({ message: 'Checking for latest updates' });
+			// If this extension is active we can just pull off the UpdateExplorer. Otherwise we need to query for them
+			updateInfo = ExtensionContainer?.updateExplorer?.updates || await updates.checkAllUpdates();
 		}
-		counter++;
-	}
+
+		const totalUpdates = updateInfo.length;
+
+		if (promptForChoice) {
+			updateInfo = await selectUpdates(updateInfo);
+		}
+
+		const selectedUpdates = updateInfo.length;
+		let counter = 1;
+
+		// sort prior to running
+		updateInfo.sort((curr: UpdateInfo, prev: UpdateInfo) => curr.priority - prev.priority);
+
+		for (const update of updateInfo) {
+			const label = `${update.productName}: ${update.latestVersion}`;
+			progress.report({
+				message: `Installing ${label} (${counter}/${selectedUpdates})`
+			});
+			try {
+				await update.action(update.latestVersion);
+				progress.report({
+					message: `Installed ${label} (${counter}/${selectedUpdates})`,
+					increment: 100 / selectedUpdates
+				});
+			} catch (error) {
+				progress.report({
+					message: `Failed to install ${label} (${counter}/${selectedUpdates})`,
+					increment: 100 / selectedUpdates
+				});
+				if (error.metadata) {
+					const { metadata } = error;
+					if ((update.productName === ProductNames.AppcInstaller || update.productName === ProductNames.Node) && metadata.errorCode === 'EACCES') {
+						const runWithSudo = await vscode.window.showErrorMessage(`Failed to update to ${label} as it must be ran with sudo`, {
+							title: 'Install with Sudo'
+						});
+						if (runWithSudo) {
+							await executeAsTask(`sudo ${metadata.command}`, update.productName);
+						}
+					}
+				} else {
+					// TODO should we show the error that we got passed?
+					await vscode.window.showErrorMessage(`Failed to update to ${label}`);
+				}
+			}
+			counter++;
+		}
+
+		// Only set the HasUpdates property if we installed all the updates
+		if (totalUpdates === selectedUpdates) {
+			ExtensionContainer.context.globalState.update(GlobalState.HasUpdates, false);
+			vscode.commands.executeCommand('setContext', GlobalState.HasUpdates, false);
+		}
+
+		vscode.commands.executeCommand(Commands.RefreshUpdates);
+		vscode.commands.executeCommand(Commands.RefreshExplorer);
+		vscode.window.showInformationMessage(`Installed ${selectedUpdates} ${selectedUpdates === 1 ? 'updates' : 'update'}`);
+
+	});
 }


### PR DESCRIPTION
This PR is a continuation of #531 and finishes off separating out the startup code into the 3 main states we care about:

* Required tooling is missing
* Tooling installed but no Titanium project open
* Tooling installed and Titanium project open

From here we can then start creating the welcome views for the activity bar that will show.

It also refactors the update commands to reduce the duplicate code we had