### PR TITLE
Add welcome views for no tooling and no titanium project states

### DIFF
--- a/package.json
+++ b/package.json
@@ -459,6 +459,11 @@
     "views": {
       "titanium": [
         {
+          "id": "titanium.view.welcome",
+          "name": "Get Started",
+          "when": "!titanium:enabled"
+        },
+        {
           "id": "titanium.view.buildExplorer",
           "name": "Build",
           "when": "titanium:enabled"
@@ -470,6 +475,13 @@
         }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "titanium.view.welcome",
+        "contents": "Titanium tooling not installed, click below to install it.\nThis will not install any platform specific tooling. To install the required platform tooling please visit [the Android](https://docs.appcelerator.com/platform/latest/#!/guide/Installing_the_Android_SDK) or [iOS documentation](https://docs.appcelerator.com/platform/latest/#!/guide/Installing_the_iOS_SDK)\n[Install Tooling](command:titanium.updates.select)",
+        "when": "titanium:toolingMissing"
+      }
+    ],
     "menus": {
       "commandPalette": [
         {
@@ -886,16 +898,6 @@
     "extends": [
       "@commitlint/config-conventional"
     ]
-  },
-  "greenkeeper": {
-    "ignore": [
-      "@types/node",
-      "@types/vscode"
-    ],
-    "commitMessages": {
-      "dependencyUpdate": "chore(deps): update ${dependency} to version ${version}",
-      "devDependencyUpdate": "chore(deps): update ${dependency} to version ${version}"
-    }
   },
   "scripts": {
     "commit": "git-cz",

--- a/package.json
+++ b/package.json
@@ -480,6 +480,11 @@
         "view": "titanium.view.welcome",
         "contents": "Titanium tooling not installed, click below to install it.\nThis will not install any platform specific tooling. To install the required platform tooling please visit [the Android](https://docs.appcelerator.com/platform/latest/#!/guide/Installing_the_Android_SDK) or [iOS documentation](https://docs.appcelerator.com/platform/latest/#!/guide/Installing_the_iOS_SDK)\n[Install Tooling](command:titanium.updates.select)",
         "when": "titanium:toolingMissing"
+      },
+      {
+        "view": "titanium.view.welcome",
+        "contents": "To use the Titanium extension you must have a Titanium project open\n[Open Project](command:workbench.action.addRootFolder)\nYou can also create a new Application or Module project\n[Create App](command:titanium.create.application)\n[Create Module](command:titanium.create.module)",
+        "when": "titanium:notProject"
       }
     ],
     "menus": {


### PR DESCRIPTION
Adds welcome views that will show when the user has no tooling installed

<img width="430" alt="Screenshot 2021-01-27 at 14 23 31" src="https://user-images.githubusercontent.com/8705251/106005225-e86c0700-60ab-11eb-986c-a91b99b7a345.png">

Or when no Titanium project is open

<img width="218" alt="Screenshot 2021-01-27 at 14 23 14" src="https://user-images.githubusercontent.com/8705251/106005187-ddb17200-60ab-11eb-8923-822792665232.png">
