### PR TITLE
Support using OSS Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Appcelerator Titanium build tools and editor additions for [Visual Studio Code](
 
 ## Features
 
+### Selecting tooling
+
+By default this extension will use the Appcelerator CLI tooling. You can switch to the Titanium CLI tooling by enabling the `General: Use Ti` property in the package settings. This can also be set per-project by setting the `titanium.general.useTi` property in a `./vscode/settings.json` file.
+
 ### Commands
 
 This extension makes the following commands available in the Command Palette to enhance your development experience.
@@ -47,7 +51,6 @@ This extension makes the following commands available in the Command Palette to 
 | `Titanium: Open related style` | Open related style |  Mac: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>s</kbd> <br> Windows/Linux: <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>s</kbd> |
 | `Titanium: Open related controller` | Open related controller |  Mac: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>x</kbd> <br> Windows/Linux: <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>x</kbd> |
 | `Titanium: Open related files` | Open related files |  Mac: <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>a</kbd> <br> Windows/Linux: <kbd>ctrl</kbd>+<kbd>alt</kbd>+<kbd>a</kbd> |
-| `Titanium: Generate autocomplete list` | Generate autocomplete list | - |
 | `Titanium: Check For Updates` | Check For Updates | - |
 | `Titanium: Install All Updates` | Install All Updates | - |
 | `Titanium: Select Updates` | Select Updates | - |
@@ -90,6 +93,7 @@ You can learn more about User and Workspace settings in the [VS Code documentati
 | `titanium.general.logLevel` | Logging level for commands being run | `info` |
 | `titanium.general.updateFrequency` | Controls the frequency for how often to show an alert if there are updates available. Updates can always be viewed in the Titanium activity pane. Accepts values in time formats like 60 minutes, 12 hours, 7 days etc. | `1 day` |
 | `titanium.general.useTerminalForBuild` | When true build/package commands will be run using the integrated terminal as opposed to using an output channel. | `true` |
+| `titanium.general.useTi` | Whether to use the OSS based tooling (alloy + ti) instead of the Appcelerator platform based tool (appc) | `false` |
 | `titanium.package.distributionOutputDirectory` | Output directory for package builds. | `dist` |
 | `titanium.project.defaultI18nLanguage` | Default language to use for i18n autocomplete. | `en` |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
-          "integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ=="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
+          "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g=="
         },
         "@szmarczak/http-timer": {
           "version": "4.0.5",
@@ -135,16 +135,16 @@
         },
         "which": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "resolved": false,
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "ws": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
-          "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
+          "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g=="
         }
       }
     },
@@ -876,13 +876,6 @@
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "12.12.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
-          "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA==",
-          "dev": true,
-          "optional": true
-        },
         "lodash": {
           "version": "4.17.14",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
@@ -1028,89 +1021,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        }
-      }
-    },
-    "@eslint/eslintrc": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
-      "integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.12.4",
-        "debug": "^4.1.1",
-        "espree": "^7.3.0",
-        "globals": "^12.1.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
-        "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-          "dev": true
-        },
-        "globals": {
-          "version": "12.4.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.8.1"
-          }
-        },
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-          "dev": true
-        },
-        "import-fresh": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-          "dev": true,
-          "requires": {
-            "parent-module": "^1.0.0",
-            "resolve-from": "^4.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-          "dev": true
         }
       }
     },
@@ -1367,28 +1277,28 @@
       "dev": true
     },
     "@nodelib/fs.scandir": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.stat": "2.0.3",
+        "@nodelib/fs.stat": "2.0.4",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
       "dev": true
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.scandir": "2.1.3",
+        "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
       }
     },
@@ -2005,7 +1915,7 @@
       "dependencies": {
         "debug": {
           "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "resolved": false,
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
@@ -2014,7 +1924,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -2046,65 +1956,18 @@
         "debug": "^4.1.1"
       },
       "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "4.22.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.1.tgz",
-          "integrity": "sha512-d5bAiPBiessSmNi8Amq/RuLslvcumxLmyhf1/Xa9IuaoFJ0YtshlJKxhlbY7l2JdEk3wS0EnmnfeJWSvADOe0g==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.22.1",
-            "@typescript-eslint/visitor-keys": "4.22.1"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "4.22.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.1.tgz",
-          "integrity": "sha512-2HTkbkdAeI3OOcWbqA8hWf/7z9c6gkmnWNGz0dKSLYLWywUlkOAQ2XcjhlKLj5xBFDf8FgAOF5aQbnLRvgNbCw==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "4.22.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.1.tgz",
-          "integrity": "sha512-p3We0pAPacT+onSGM+sPR+M9CblVqdA9F1JEdIqRVlxK5Qth4ochXQgIyb9daBomyQKAXbygxp1aXQRV0GC79A==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.22.1",
-            "@typescript-eslint/visitor-keys": "4.22.1",
-            "debug": "^4.1.1",
-            "globby": "^11.0.1",
-            "is-glob": "^4.0.1",
-            "semver": "^7.3.2",
-            "tsutils": "^3.17.1"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "4.22.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.1.tgz",
-          "integrity": "sha512-WPkOrIRm+WCLZxXQHCi+WG8T2MMTUFR70rWjdWYddLT7cEfb2P4a3O/J2U1FBVsSFTocXLCoXWY6MZGejeStvQ==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.22.1",
-            "eslint-visitor-keys": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "resolved": false,
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
         },
-        "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-          "dev": true
-        },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -2256,14 +2119,6 @@
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
-      },
-      "dependencies": {
-        "indent-string": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-          "dev": true
-        }
       }
     },
     "ajv": {
@@ -2580,6 +2435,12 @@
         "es-abstract": "^1.18.0-next.1"
       }
     },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -2672,15 +2533,13 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "azure-devops-node-api": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
-      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
+      "integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
       "dev": true,
       "requires": {
-        "os": "0.1.1",
-        "tunnel": "0.0.4",
-        "typed-rest-client": "1.2.0",
-        "underscore": "1.8.3"
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
       }
     },
     "babel-runtime": {
@@ -3298,17 +3157,26 @@
       "dev": true
     },
     "cheerio": {
-      "version": "1.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.6.tgz",
-      "integrity": "sha512-hjx1XE1M/D5pAtMgvWwE21QClmAEeGHOIDfycgmndisdNgI6PE1cGRQkMGBcsbUbmEQyWu5PJLUcAOjtQS8DWw==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.9.tgz",
+      "integrity": "sha512-QF6XVdrLONO6DXRF5iaolY+odmhj2CLj+xzNod7INPWMi/x9X4SOylH0S/vaPpX+AUU6t04s34SQNh7DbkuCng==",
       "dev": true,
       "requires": {
-        "cheerio-select": "^1.3.0",
+        "cheerio-select": "^1.4.0",
         "dom-serializer": "^1.3.1",
-        "domhandler": "^4.1.0",
+        "domhandler": "^4.2.0",
         "htmlparser2": "^6.1.0",
         "parse5": "^6.0.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.1"
+        "parse5-htmlparser2-tree-adapter": "^6.0.1",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
       }
     },
     "cheerio-select": {
@@ -3422,6 +3290,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "ci-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -5411,7 +5284,7 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "resolved": false,
           "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
           "dev": true,
           "requires": {
@@ -5419,15 +5292,14 @@
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-          "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
-          "dev": true
+          "version": "7.12.11",
+          "resolved": false,
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
         },
         "@babel/highlight": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-          "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+          "version": "7.13.10",
+          "resolved": false,
+          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.0",
@@ -5435,9 +5307,15 @@
             "js-tokens": "^4.0.0"
           },
           "dependencies": {
+            "@babel/helper-validator-identifier": {
+              "version": "7.14.0",
+              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+              "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+              "dev": true
+            },
             "chalk": {
               "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "resolved": false,
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "dev": true,
               "requires": {
@@ -5448,16 +5326,66 @@
             }
           }
         },
+        "@eslint/eslintrc": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
+          "integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.12.4",
+            "debug": "^4.1.1",
+            "espree": "^7.3.0",
+            "globals": "^12.1.0",
+            "ignore": "^4.0.6",
+            "import-fresh": "^3.2.1",
+            "js-yaml": "^3.13.1",
+            "minimatch": "^3.0.4",
+            "strip-json-comments": "^3.1.1"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "6.12.6",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+              "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+              "dev": true,
+              "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "globals": {
+              "version": "12.4.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+              "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+              "dev": true,
+              "requires": {
+                "type-fest": "^0.8.1"
+              }
+            },
+            "import-fresh": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+              "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+              "dev": true,
+              "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+              }
+            }
+          }
+        },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.0",
+          "resolved": false,
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5466,7 +5394,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "resolved": false,
               "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "dev": true,
               "requires": {
@@ -5475,7 +5403,7 @@
             },
             "supports-color": {
               "version": "7.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "resolved": false,
               "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "dev": true,
               "requires": {
@@ -5486,7 +5414,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -5495,13 +5423,13 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "resolved": false,
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "cross-spawn": {
           "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
@@ -5512,7 +5440,7 @@
         },
         "debug": {
           "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "resolved": false,
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
@@ -5520,50 +5448,56 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "version": "2.0.0",
+          "resolved": false,
+          "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "ignore": {
           "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "resolved": false,
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
         "lodash": {
           "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "resolved": false,
           "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "path-key": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
         "regexpp": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
           "dev": true
         },
         "shebang-command": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
@@ -5572,13 +5506,13 @@
         },
         "shebang-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
@@ -5587,7 +5521,7 @@
         },
         "strip-json-comments": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
         }
@@ -6199,9 +6133,9 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-glob": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -6237,13 +6171,13 @@
           "dev": true
         },
         "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
           "dev": true,
           "requires": {
             "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
+            "picomatch": "^2.2.3"
           }
         },
         "to-regex-range": {
@@ -6275,9 +6209,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -6474,12 +6408,6 @@
             "braces": "^3.0.1",
             "picomatch": "^2.2.3"
           }
-        },
-        "picomatch": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-          "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
-          "dev": true
         },
         "to-regex-range": {
           "version": "5.0.1",
@@ -6969,6 +6897,23 @@
             "pinkie-promise": "^2.0.0"
           }
         },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
         "read-pkg": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -7252,9 +7197,9 @@
       }
     },
     "globals": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
-      "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.7.0.tgz",
+      "integrity": "sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -7269,9 +7214,9 @@
       }
     },
     "globby": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
-      "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+      "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
@@ -7467,9 +7412,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -7776,9 +7721,9 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -7847,13 +7792,6 @@
       "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "requires": {
         "ci-info": "^1.5.0"
-      },
-      "dependencies": {
-        "ci-info": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
-        }
       }
     },
     "is-core-module": {
@@ -8999,16 +8937,6 @@
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
         },
-        "log-symbols": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "is-unicode-supported": "^0.1.0"
-          }
-        },
         "micromatch": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -9065,18 +8993,6 @@
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "path-type": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-          "dev": true
-        },
-        "picomatch": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-          "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
           "dev": true
         },
         "shebang-command": {
@@ -9203,15 +9119,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
-        },
-        "rxjs": {
-          "version": "6.6.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
         },
         "string-width": {
           "version": "4.2.2",
@@ -9475,12 +9382,13 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "requires": {
-        "chalk": "^4.0.0"
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9898,9 +9806,9 @@
           },
           "dependencies": {
             "hosted-git-info": {
-              "version": "2.8.9",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-              "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+              "version": "2.8.8",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+              "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
               "dev": true
             },
             "normalize-package-data": {
@@ -10079,12 +9987,6 @@
         "kind-of": "^6.0.3"
       },
       "dependencies": {
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-          "dev": true
-        },
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -10202,10 +10104,55 @@
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "debug": {
@@ -10283,6 +10230,15 @@
           "dev": true,
           "requires": {
             "p-locate": "^5.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
           }
         },
         "p-limit": {
@@ -10948,12 +10904,6 @@
             "wrap-ansi": "^6.2.0"
           }
         },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -11267,12 +11217,6 @@
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
       }
-    },
-    "os": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M=",
-      "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -11691,23 +11635,10 @@
       "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
     },
     "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
     },
     "pathval": {
       "version": "1.1.1",
@@ -11734,9 +11665,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
       "dev": true
     },
     "pify": {
@@ -11891,17 +11822,6 @@
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
         "tar-fs": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -11912,19 +11832,6 @@
             "mkdirp-classic": "^0.5.2",
             "pump": "^3.0.0",
             "tar-stream": "^2.1.4"
-          }
-        },
-        "tar-stream": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-          "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
-          "dev": true,
-          "requires": {
-            "bl": "^4.0.3",
-            "end-of-stream": "^1.4.1",
-            "fs-constants": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1"
           }
         }
       }
@@ -11997,12 +11904,12 @@
       }
     },
     "proxy-addr": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.9.1"
+        "ipaddr.js": "1.9.0"
       }
     },
     "ps-tree": {
@@ -12080,6 +11987,12 @@
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       }
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -12386,9 +12299,9 @@
       }
     },
     "resolve-alpn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
-      "integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.1.2.tgz",
+      "integrity": "sha512-8OyfzhAtA32LVUsJSke3auIyINcwdh5l3cvYKdKO0nvsYSKuiLfTM5i78PJswFPT8y6cPW+L1v6/hE95chcpDA=="
     },
     "resolve-dir": {
       "version": "1.0.1",
@@ -12470,10 +12383,13 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "run-queue": {
       "version": "1.0.3",
@@ -12484,9 +12400,9 @@
       }
     },
     "rxjs": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -12715,6 +12631,17 @@
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
+      }
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
       }
     },
     "signal-exit": {
@@ -13227,9 +13154,9 @@
       }
     },
     "ssri": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
-      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "requires": {
         "figgy-pudding": "^3.5.1"
       }
@@ -13501,23 +13428,26 @@
       }
     },
     "table": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.0.tgz",
-      "integrity": "sha512-SAM+5p6V99gYiiy2gT5ArdzgM1dLDed0nkrWmG6Fry/bUS/m9x83BwpJUOf1Qj/x2qJd+thL6IkIx7qPGRxqBw==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.0.8.tgz",
+      "integrity": "sha512-OBAdezyozae8IvjHGXBDHByVkLCcsmffXUSj8LXkNb0SluRd4ug3GFCjk6JynZONIPhOkyr0Nnvbq1rlIspXyQ==",
       "dev": true,
       "requires": {
         "ajv": "^8.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
         "lodash.clonedeep": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0"
+        "string-width": "^4.2.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.3.0.tgz",
-          "integrity": "sha512-RYE7B5An83d7eWnDR8kbdaIFqmKCNsP16ay1hDbJEU+sa0e3H9SebskCt0Uufem6cfAVu7Col6ubcn/W+Sm8/Q==",
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.0.1.tgz",
+          "integrity": "sha512-46ZA4TalFcLLqX1dEU3dhdY38wAtDydJ4e7QQTVekLUTzXkb1LfqU6VOBXC/a9wiv4T094WURqJH6ZitF92Kqw==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -13772,9 +13702,9 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "titanium-editor-commons": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/titanium-editor-commons/-/titanium-editor-commons-1.0.4.tgz",
-      "integrity": "sha512-mh/aiwM6j2b73sSL5kB5QkuFUOZX0Nq925vpUPElmMCAcKOBljsz3cvbMdzgP/fGO4/jWuD8aw5d8uPmTTtpBA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/titanium-editor-commons/-/titanium-editor-commons-1.2.0.tgz",
+      "integrity": "sha512-+f+x/h8GxQGEyfYlmx6AihzolLAnLkUzwIluTMUxxbpIyDtl0An8ZZaGVwafcippRSN06mTwM3xxqmszZ/qvAw==",
       "requires": {
         "appcd-subprocess": "^3.0.1",
         "fs-extra": "^9.0.0",
@@ -14081,9 +14011,9 @@
       }
     },
     "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "dev": true
     },
     "tunnel-agent": {
@@ -14130,13 +14060,25 @@
       }
     },
     "typed-rest-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
+      "integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
       "dev": true,
       "requires": {
-        "tunnel": "0.0.4",
-        "underscore": "1.8.3"
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        }
       }
     },
     "typedarray": {
@@ -14166,9 +14108,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.13.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.5.tgz",
-      "integrity": "sha512-xtB8yEqIkn7zmOyS2zUNBsYCBRhDkvlNxMMY2smuJ/qA8NCHeQvKCF3i9Z4k8FJH4+PJvZRtMrPynfZ75+CSZw==",
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
+      "integrity": "sha512-rRprLwl8RVaS+Qvx3Wh5hPfPBn9++G6xkGlUupya0s5aDmNjI7z3lnRLB3u7sN4OmbB0pWgzhM9BEJyiWAwtAA==",
       "dev": true,
       "optional": true
     },
@@ -14195,9 +14137,9 @@
       }
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
       "dev": true
     },
     "union-value": {
@@ -14483,12 +14425,12 @@
       }
     },
     "vsce": {
-      "version": "1.87.1",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.87.1.tgz",
-      "integrity": "sha512-3tSUWZl9AmhZrqy/UVUpdPODSzBiCGjIr/AMSSgF2PuFLSdrh+6kiOr2Ath7bpQEXOxf55hNgz3qdO5MuEJmww==",
+      "version": "1.88.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.88.0.tgz",
+      "integrity": "sha512-FS5ou3G+WRnPPr/tWVs8b/jVzeDacgZHy/y7/QQW7maSPFEAmRt2bFGUJtJVEUDLBqtDm/3VGMJ7D31cF2U1tw==",
       "dev": true,
       "requires": {
-        "azure-devops-node-api": "^7.2.0",
+        "azure-devops-node-api": "^10.2.2",
         "chalk": "^2.4.2",
         "cheerio": "^1.0.0-rc.1",
         "commander": "^6.1.0",
@@ -14504,7 +14446,7 @@
         "read": "^1.0.7",
         "semver": "^5.1.0",
         "tmp": "0.0.29",
-        "typed-rest-client": "1.2.0",
+        "typed-rest-client": "^1.8.4",
         "url-join": "^1.1.0",
         "yauzl": "^2.3.1",
         "yazl": "^2.2.2"
@@ -14580,28 +14522,23 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "resolved": false,
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "mkdirp": {
           "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "resolved": false,
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "requires": {
             "minimist": "^1.2.5"
           }
-        },
-        "vscode-debugprotocol": {
-          "version": "1.47.0",
-          "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.47.0.tgz",
-          "integrity": "sha512-ii7oCz3Wfr/SGtFr5AYop5dJm0dUmpg0hq2lTzTBdaht8nSheYMMjPntxULBR+2TUxXLcCKFZkF2UEJQduYsIQ=="
         }
       }
     },
     "vscode-debugprotocol": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.37.0.tgz",
-      "integrity": "sha512-ppZLEBbFRVNsK0YpfgFi/x2CDyihx0F+UpdKmgeJcvi05UgSXYdO0n9sDVYwoGvvYQPvlpDQeWuY0nloOC4mPA=="
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.47.0.tgz",
+      "integrity": "sha512-ii7oCz3Wfr/SGtFr5AYop5dJm0dUmpg0hq2lTzTBdaht8nSheYMMjPntxULBR+2TUxXLcCKFZkF2UEJQduYsIQ=="
     },
     "vscode-extension-tester": {
       "version": "4.0.3",
@@ -14967,12 +14904,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -15127,12 +15058,6 @@
           "version": "5.0.5",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
           "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "20.2.4",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -440,6 +440,11 @@
           "default": true,
           "description": "When true build/package commands will be run using the integrated terminal as opposed to using an output channel."
         },
+        "titanium.general.useTi": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to use the OSS based tooling (alloy + ti) instead of the Appcelerator platform based tool (appc)"
+        },
         "titanium.package.distributionOutputDirectory": {
           "type": "string",
           "default": "dist",
@@ -978,7 +983,7 @@
     "klaw-sync": "^6.0.0",
     "ms": "^2.1.3",
     "semver": "^7.3.5",
-    "titanium-editor-commons": "^1.0.4",
+    "titanium-editor-commons": "^1.2.0",
     "uuid": "^8.3.2",
     "vscode-chrome-debug-core": "^6.8.9",
     "vscode-debugadapter": "^1.47.0",

--- a/scripts/templates/README.md.ejs
+++ b/scripts/templates/README.md.ejs
@@ -23,6 +23,10 @@ Appcelerator Titanium build tools and editor additions for [Visual Studio Code](
 
 ## Features
 
+### Selecting tooling
+
+By default this extension will use the Appcelerator CLI tooling. You can switch to the Titanium CLI tooling by enabling the `General: Use Ti` property in the package settings. This can also be set per-project by setting the `titanium.general.useTi` property in a `settings.json` file.
+
 ### Commands
 
 This extension makes the following commands available in the Command Palette to enhance your development experience.

--- a/src/commands/alloyGenerate.ts
+++ b/src/commands/alloyGenerate.ts
@@ -63,7 +63,7 @@ Promise<{ cwd: string; filePaths: string[]; name: string; type: AlloyComponentTy
 	return { cwd, filePaths, name, type };
 }
 
-export async function generateComponent (type: AlloyComponentType, folder: AlloyComponentFolder, extension: AlloyComponentExtension): Promise<void> {
+export async function generateComponent (type: Exclude<AlloyComponentType, AlloyComponentType.Model>, folder: AlloyComponentFolder, extension: AlloyComponentExtension): Promise<void> {
 	let name;
 	try {
 		const creationArgs = await promptForDetails(type, folder, extension);

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -1,12 +1,10 @@
 import * as path from 'path';
-import { workspace } from 'vscode';
+import { ProgressLocation, window, workspace } from 'vscode';
 import { ExtensionContainer } from '../container';
 import project from '../project';
 import { selectPlatform } from '../quickpicks/common';
-import { cleanAppArguments, isValidPlatform } from '../utils';
+import { isValidPlatform, quoteArgument } from '../utils';
 import { handleInteractionError, InteractionError } from './common';
-
-import { CleanAppOptions } from '../types/cli';
 
 export async function cleanApplication (): Promise<void> {
 	try {
@@ -17,13 +15,23 @@ export async function cleanApplication (): Promise<void> {
 			const platformInfo = await selectPlatform(undefined, isValidPlatform);
 			projectDir = path.join(projectDir, platformInfo.id);
 		}
+		await window.withProgress({ cancellable: false, location: ProgressLocation.Notification, title: 'Cleaning project' }, async (progress) => {
+			const command = ExtensionContainer.isUsingTi() ? 'ti' : 'appc';
+			const args = [
+				'clean',
+				'--project-dir', projectDir,
+				'--log-level', logLevel
+			];
 
-		const cleanArguments: CleanAppOptions = {
-			logLevel,
-			projectDir,
-		};
-		const args = cleanAppArguments(cleanArguments);
-		ExtensionContainer.terminal.runCommand(args);
+			if (!ExtensionContainer.isUsingTi()) {
+				args.unshift('ti');
+			}
+
+			const quotedArgs =  args.map(arg => quoteArgument(arg));
+
+			await ExtensionContainer.terminal.runInBackground(command, quotedArgs);
+		});
+
 	} catch (error) {
 		if (error instanceof InteractionError) {
 			await handleInteractionError(error);

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -15,7 +15,7 @@ export async function cleanApplication (): Promise<void> {
 			const platformInfo = await selectPlatform(undefined, isValidPlatform);
 			projectDir = path.join(projectDir, platformInfo.id);
 		}
-		await window.withProgress({ cancellable: false, location: ProgressLocation.Notification, title: 'Cleaning project' }, async (progress) => {
+		await window.withProgress({ cancellable: false, location: ProgressLocation.Notification, title: 'Cleaning project' }, async () => {
 			const command = ExtensionContainer.isUsingTi() ? 'ti' : 'appc';
 			const args = [
 				'clean',

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -67,7 +67,7 @@ export function checkLogin (): void {
 		error.interactionChoices.push({
 			title: 'Login',
 			run: () => {
-				ExtensionContainer.terminal.runCommand([ 'login' ], { forceTerminal: true });
+				ExtensionContainer.terminal.runCommand([ 'login' ]);
 			}
 		});
 		throw error;

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -54,6 +54,10 @@ export class InteractionError extends Error {
  * Check Appcelerator login and prompt if necessary.
  */
 export function checkLogin (): void {
+	if (ExtensionContainer.isUsingTi()) {
+		return;
+	}
+
 	if (!ExtensionContainer.appc.isUserLoggedIn()) {
 		window.showInformationMessage('Please log in to the Appcelerator platform');
 		const error = new InteractionError('You are not logged in. Please log in to continue');

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -48,3 +48,23 @@ export function sleep (time: number): Promise<void> {
 		}, time);
 	});
 }
+
+export class CommandError extends Error {
+	public code = 'E_COMMAND_ERROR';
+	public command: string;
+	public exitCode: number;
+	public output?: string;
+	public signal?: string;
+
+	constructor(message: string, command: string, exitCode: number, output?: string, signal?: string) {
+		super(message);
+		this.command = command;
+		this.exitCode = exitCode;
+		this.output = output;
+		this.signal = signal;
+	}
+}
+
+export interface CommandResponse {
+	output: string;
+}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -25,8 +25,8 @@ export class Configuration {
 			.update(section, value, target);
 	}
 
-	private onConfigurationChanged (e: ConfigurationChangeEvent): void {
-		ExtensionContainer.resetConfig();
+	private onConfigurationChanged (configEvent: ConfigurationChangeEvent): void {
+		ExtensionContainer.resetConfig(configEvent);
 	}
 }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -19,9 +19,9 @@ export class Configuration {
 				.get<T>(section === undefined ? ExtensionName : section, defaultValue)!;
 	}
 
-	public update (section: string, value: any, target: ConfigurationTarget, resourece?: Uri): Thenable<void> {
+	public update (section: string, value: unknown, target: ConfigurationTarget, resource?: Uri): Thenable<void> {
 		return workspace
-			.getConfiguration(ExtensionName, target === ConfigurationTarget.Global ? undefined : resourece!)
+			.getConfiguration(ExtensionName, target === ConfigurationTarget.Global ? undefined : resource!)
 			.update(section, value, target);
 	}
 

--- a/src/debugger/titaniumDebugHelper.ts
+++ b/src/debugger/titaniumDebugHelper.ts
@@ -64,9 +64,9 @@ async function handleCustomEvent(event: vscode.DebugSessionCustomEvent): Promise
 			const tcpPort = `tcp:${providedArgs.port}`;
 
 			if (providedArgs.target === 'emulator') {
-				const { stdout } = await ExtensionContainer.terminal.runInBackground(adbPath, [ 'forward', '--list' ]);
+				const { output } = await ExtensionContainer.terminal.runInBackground(adbPath, [ 'forward', '--list' ]);
 
-				for (const line of stdout.split('\n')) {
+				for (const line of output.split('\n')) {
 					if (!line.includes(tcpPort)) {
 						continue;
 					}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,9 +47,13 @@ export function deactivate (): void {
  * we're installing from a missing tooling scenario
  */
 export async function startup (): Promise<void> {
-	const { missing } = await environment.validateEnvironment();
+
+	const { missing } = await environment.validateEnvironment(undefined, !ExtensionContainer.isUsingTi());
 
 	if (missing.length) {
+		// We need to set Enabled here just incase are called by a change to the useTi setting
+		// where the environment was previously valid but now we are missing tooling
+		ExtensionContainer.setContext(GlobalState.Enabled, false);
 		ExtensionContainer.setContext(GlobalState.MissingTooling, true);
 		return;
 	}
@@ -59,6 +63,7 @@ export async function startup (): Promise<void> {
 	project.load();
 
 	if (!project.isTitaniumProject()) {
+		ExtensionContainer.setContext(GlobalState.Enabled, false);
 		ExtensionContainer.setContext(GlobalState.NotTitaniumProject, true);
 		return;
 	}

--- a/src/project.ts
+++ b/src/project.ts
@@ -11,7 +11,6 @@ import { parseXmlString } from './common/utils';
 const TIAPP_FILENAME = 'tiapp.xml';
 const TIMODULEXML_FILENAME = 'timodule.xml';
 const MANIFEST_FILENAME = 'manifest';
-const DASHBOARD_URL_ROOT = 'https://platform.axway.com/#/app/';
 
 interface ModuleInformation {
 	path: string;

--- a/src/providers/definition/common.ts
+++ b/src/providers/definition/common.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as related from '../../related';
 import * as utils from '../../utils';
 
-import { TextDocument, workspace } from 'vscode';
+import { TextDocument } from 'vscode';
 import { ExtensionContainer } from '../../container';
 
 export interface DefinitionSuggestion {

--- a/src/providers/definition/viewHoverProvider.ts
+++ b/src/providers/definition/viewHoverProvider.ts
@@ -1,6 +1,6 @@
 import * as definitionProviderHelper from './definitionProviderHelper';
 
-import { CancellationToken, HoverProvider, Position, TextDocument, Hover } from 'vscode';
+import { HoverProvider, Position, TextDocument, Hover } from 'vscode';
 
 export class ViewHoverProvider implements HoverProvider {
 

--- a/src/quickpicks/creation.ts
+++ b/src/quickpicks/creation.ts
@@ -3,6 +3,7 @@ import Appc from '../appc';
 import { nameForPlatform, platforms } from '../utils';
 import { CustomQuickPick, quickPick } from './common';
 import { appc } from 'titanium-editor-commons/updates';
+import { ExtensionContainer } from '../container';
 
 export interface CodeBase {
 	android?: 'java' | 'kotlin'
@@ -40,16 +41,18 @@ export async function selectCodeBases(platforms: string[]): Promise<CodeBase|und
 		return undefined;
 	}
 
-	// CLI 8.1.1 did not correctly handle the --ios-code-base option, so only ask for codebase
-	// options if they're using 8.1.1 or above
-	const selectedCLI = await appc.core.checkInstalledVersion();
+	if (!ExtensionContainer.isUsingTi()) {
+		// CLI 8.1.1 did not correctly handle the --ios-code-base option, so only ask for codebase
+		// options if they're using 8.1.1 or above
+		const selectedCLI = await appc.core.checkInstalledVersion();
 
-	if (!selectedCLI) {
-		return;
-	}
+		if (!selectedCLI) {
+			return;
+		}
 
-	if (semver.lt(selectedCLI, '8.1.1')) {
-		return undefined;
+		if (semver.lt(selectedCLI, '8.1.1')) {
+			return undefined;
+		}
 	}
 
 	if (platforms.includes('android')) {

--- a/src/tasks/commandTaskProvider.ts
+++ b/src/tasks/commandTaskProvider.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
 import { TaskExecutionContext, Platform, ProjectType } from './tasksHelper';
-import { TaskPseudoTerminal, CommandError } from './taskPseudoTerminal';
+import { TaskPseudoTerminal } from './taskPseudoTerminal';
 import { TaskHelper, Helpers } from './helpers';
 import { UserCancellation, handleInteractionError, InteractionError, checkLogin } from '../commands/common';
 import { LogLevel } from '../types/common';
+import { CommandError } from '../common/utils';
 
 function getPlatform (task: TitaniumTaskBase): Platform {
 	if (task.definition.titaniumBuild.platform === 'android' || task.definition.titaniumBuild.android !== undefined) {

--- a/src/tasks/helpers/android.ts
+++ b/src/tasks/helpers/android.ts
@@ -30,7 +30,7 @@ export interface AndroidPackageTaskTitaniumBuildBase extends AppPackageTaskTitan
 export class AndroidHelper extends TaskHelper {
 
 	public async resolveAppBuildCommandLine (context: TaskExecutionContext, definition: AndroidBuildTaskTitaniumBuildBase): Promise<string> {
-		const builder = CommandBuilder.create('appc', 'run');
+		const builder = this.createBuilder();
 
 		await this.resolveCommonAppOptions(context, definition, builder);
 
@@ -45,7 +45,7 @@ export class AndroidHelper extends TaskHelper {
 	}
 
 	public async resolveAppPackageCommandLine(context: TaskExecutionContext, definition: AndroidPackageTaskTitaniumBuildBase): Promise<string> {
-		const builder = CommandBuilder.create('appc', 'run');
+		const builder = this.createBuilder();
 
 		await this.resolveCommonPackagingOptions(context, definition, builder);
 
@@ -72,7 +72,7 @@ export class AndroidHelper extends TaskHelper {
 	}
 
 	public async resolveModuleBuildCommandLine (context: TaskExecutionContext, definition: BuildTaskTitaniumBuildBase): Promise<string> {
-		const builder = CommandBuilder.create('appc', 'run');
+		const builder = this.createBuilder();
 
 		this.resolveCommonOptions(context, definition, builder);
 
@@ -80,7 +80,7 @@ export class AndroidHelper extends TaskHelper {
 	}
 
 	public async resolveModulePackageCommandLine (context: TaskExecutionContext, definition: PackageTaskTitaniumBuildBase): Promise<string> {
-		const builder = CommandBuilder.create('appc', 'run');
+		const builder = this.createBuilder();
 
 		this.resolveCommonOptions(context, definition, builder);
 

--- a/src/tasks/helpers/android.ts
+++ b/src/tasks/helpers/android.ts
@@ -1,6 +1,5 @@
 import { TaskExecutionContext, runningTasks } from '../tasksHelper';
 import { TaskHelper } from './base';
-import { CommandBuilder } from '../commandBuilder';
 import { enterAndroidKeystoreInfo } from '../../quickpicks/build/android';
 import { KeystoreInfo } from '../../types/common';
 import { AppBuildTaskTitaniumBuildBase, BuildTaskDefinitionBase, BuildTaskTitaniumBuildBase } from '../buildTaskProvider';

--- a/src/tasks/helpers/base.ts
+++ b/src/tasks/helpers/base.ts
@@ -158,4 +158,12 @@ export abstract class TaskHelper {
 	public storeLastState (type: WorkspaceState, buildOptions: TitaniumBuildBase): void {
 		ExtensionContainer.context.workspaceState.update(type, buildOptions);
 	}
+
+	public createBuilder (): CommandBuilder {
+		if (ExtensionContainer.isUsingTi()) {
+			return CommandBuilder.create('ti', 'build');
+		} else {
+			return CommandBuilder.create('appc', 'run');
+		}
+	}
 }

--- a/src/tasks/helpers/ios.ts
+++ b/src/tasks/helpers/ios.ts
@@ -40,7 +40,7 @@ export interface IosPackageTaskTitaniumBuildBase extends AppPackageTaskTitaniumB
 export class IosHelper extends TaskHelper {
 
 	public async resolveAppBuildCommandLine (context: TaskExecutionContext, definition: IosBuildTaskTitaniumBuildBase): Promise<string> {
-		const builder = CommandBuilder.create('appc', 'run');
+		const builder = this.createBuilder();
 
 		await this.resolveCommonAppOptions(context, definition, builder);
 
@@ -83,7 +83,7 @@ export class IosHelper extends TaskHelper {
 	}
 
 	public async resolveAppPackageCommandLine(context: TaskExecutionContext, definition: IosPackageTaskTitaniumBuildBase): Promise<string> {
-		const builder = CommandBuilder.create('appc', 'run');
+		const builder = this.createBuilder();
 
 		await this.resolveCommonPackagingOptions(context, definition, builder);
 
@@ -122,7 +122,7 @@ export class IosHelper extends TaskHelper {
 	}
 
 	public async resolveModuleBuildCommandLine (context: TaskExecutionContext, definition: BuildTaskTitaniumBuildBase): Promise<string> {
-		const builder = CommandBuilder.create('appc', 'run');
+		const builder = this.createBuilder();
 
 		this.resolveCommonOptions(context, definition, builder);
 
@@ -130,7 +130,7 @@ export class IosHelper extends TaskHelper {
 	}
 
 	public async resolveModulePackageCommandLine (context: TaskExecutionContext, definition: PackageTaskTitaniumBuildBase): Promise<string> {
-		const builder = CommandBuilder.create('appc', 'run');
+		const builder = this.createBuilder();
 
 		this.resolveCommonOptions(context, definition, builder);
 

--- a/src/tasks/helpers/ios.ts
+++ b/src/tasks/helpers/ios.ts
@@ -4,7 +4,6 @@ import { getCorrectCertificateName } from '../../utils';
 import project from '../../project';
 import { IosCertificateType, IosCert } from '../../types/common';
 import { TaskHelper } from './base';
-import { CommandBuilder } from '../commandBuilder';
 import { BuildTaskDefinitionBase, AppBuildTaskTitaniumBuildBase, BuildTaskTitaniumBuildBase } from '../buildTaskProvider';
 import { AppPackageTaskTitaniumBuildBase, PackageTaskDefinitionBase, PackageTaskTitaniumBuildBase } from '../packageTaskProvider';
 import { WorkspaceState } from '../../constants';

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1,16 +1,12 @@
-import { ChildProcess, spawn, SpawnOptions } from 'child_process';
-import { Terminal as VSTerminal, window, OutputChannel, commands } from 'vscode';
-import { GlobalState } from './constants';
+import { spawn, SpawnOptions } from 'child_process';
+import { Terminal as VSTerminal, window } from 'vscode';
 import { CommandError, CommandResponse } from './common/utils';
-import { ExtensionContainer } from './container';
 
 export default class Terminal {
 
 	private name: string;
 	private terminal: VSTerminal|undefined;
 	private command: string;
-	private proc: ChildProcess|undefined;
-	private channel: OutputChannel|undefined;
 
 	constructor (name: string, command = 'appc') {
 
@@ -24,40 +20,18 @@ export default class Terminal {
 		this.command = command;
 	}
 
-	public setCommandPath (commandPath: string): void {
-		this.command = commandPath;
-	}
-
-	public runCommand (args: string[], { forceTerminal = false } = {}): void {
-		if (ExtensionContainer.config.general.useTerminalForBuild || forceTerminal) {
-			if (!this.terminal) {
-				this.terminal = window.createTerminal({ name: this.name });
-			}
-
-			const activeTerminal = window.activeTerminal;
-			// Only call show if we arent the active terminal
-			if (!activeTerminal || activeTerminal.name !== this.terminal.name) {
-				this.terminal.show();
-			}
-			this.clear();
-			this.terminal.sendText(`${this.command} ${args.join(' ')}`);
-		} else {
-			this.runCommandInOutput(args);
-		}
-	}
-
-	public executeCommand (command: string): void {
+	public runCommand (args: string[]): void {
 		if (!this.terminal) {
 			this.terminal = window.createTerminal({ name: this.name });
 		}
+
 		const activeTerminal = window.activeTerminal;
 		// Only call show if we arent the active terminal
 		if (!activeTerminal || activeTerminal.name !== this.terminal.name) {
 			this.terminal.show();
 		}
 		this.clear();
-		this.terminal.sendText(command);
-
+		this.terminal.sendText(`${this.command} ${args.join(' ')}`);
 	}
 
 	public runInBackground (command: string, args: string[], spawnOptions: SpawnOptions = { shell: true }): Promise<CommandResponse> {
@@ -85,57 +59,9 @@ export default class Terminal {
 		});
 	}
 
-	public runCommandInOutput (args: string[], cwd?: string): ChildProcess|undefined {
-		if (this.proc) {
-			window.showInformationMessage('A build is already in progress');
-			return;
-		}
-		if (!this.channel) {
-			this.channel = window.createOutputChannel('Appcelerator');
-		}
-		args.push('--no-prompt');
-		this.channel.clear();
-		this.channel.append(`${this.command} ${args.join(' ')}\n\n`);
-		this.proc = spawn(this.command, args, { shell: true, cwd  });
-		this.proc.stdout?.on('data', data => {
-			ExtensionContainer.context.globalState.update(GlobalState.Running, true);
-			commands.executeCommand('setContext', GlobalState.Running, true);
-			const message = data.toString();
-			this.channel?.append(message);
-		});
-		this.proc.stderr?.on('data', data => {
-			const message = data.toString();
-			this.channel?.append(message);
-		});
-		this.proc.on('close', () => {
-			this.proc = undefined;
-		});
-		this.proc.on('exit', () => {
-			ExtensionContainer.context.globalState.update(GlobalState.Running, false);
-			commands.executeCommand('setContext', GlobalState.Running, false);
-			this.proc = undefined;
-		});
-
-		this.channel.show();
-		return this.proc;
-	}
-
 	public clear (): void {
 		if (this.terminal) {
 			this.terminal.sendText('clear');
-		}
-	}
-
-	public stop (): void {
-		if (this.proc) {
-			this.proc.kill();
-			this.proc = undefined;
-		}
-	}
-
-	public showOutput (): void {
-		if (this.channel) {
-			this.channel.show();
 		}
 	}
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -20,6 +20,7 @@ export interface Config {
 		displayBuildCommandInConsole: boolean;
 		logLevel: LogLevel;
 		useTerminalForBuild: boolean;
+		useTi: boolean;
 		updateFrequency: string;
 	};
 	package: {


### PR DESCRIPTION
This PR introduces support for using the Ti and Alloy (OSS) tooling directly instead of the Appc tooling. It is enabled using the `titanium.general.useTi` setting which can be set in the global settings or on a per-workspace/project level with a `.vscode/settings.json` file.

Again the PR is split up into the individual components to hopefully make it easier to review, I'll squash all relevant commits before merge to keep the changelog tidy.

The following are standalone commits that won't be squashed:

* 36bb58bdda34d9aad769286ef0304a52f39e6a08 - Removes most of the Terminal class as I realised it's mostly unused after we moved to tasks, we can probably remove this completely once we remove the Appc tooling.
* 7d4499a47325180d7732931dd6b3938d23290a28 - Linting stuff
* 9231fbc74f6482c7267b54be57f419e14bd4a1cd - Reusing some dupe code

If anyone is an eager beaver and wants to try this out, there is a pre-release [here](https://github.com/ewanharris/vscode-appcelerator-titanium/releases/tag/oss-tooling-prerelease)