### PR TITLE
Move integration tests to use OSS tooling, run in Actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,6 @@ indent_style = 2
 
 [*.json]
 indent_style = 4
+
+[*.yml]
+indent_style = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,25 @@ on:
   - push
 
 jobs:
-  Test:
-    name: ${{ matrix.os }} - Tests
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install NPM dependencies
+        run: npm ci
+      - name: Type Check
+        run: npm run compile
+      - name: Lint
+        run: npm run lint
+
+  Unit-Test:
+    name: ${{ matrix.os }} - Unit Tests
+    needs: Lint
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -23,18 +40,25 @@ jobs:
         with:
           run: npm run test
 
-  Lint:
-    runs-on: ubuntu-latest
+  Integration-Test:
+    name: ${{ matrix.version }} - Integration Tests
+    runs-on: macos-latest
+    needs: Lint
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ 1.49.0, latest, insider ]
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: Install NPM dependencies
-        run: npm ci
-      - name: Type Check
-        run: npm run compile
-      - name: Lint
-        run: npm run lint
+      - name: Install dependencies and requirements
+        run: |
+          npm ci
+          npm i titanium alloy -g
+          ti sdk install latest
+      - name: Run Integration Tests
+        run: npm run test:integration
+        env:
+          CODE_VERSION: ${{ matrix.version }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,21 +49,6 @@ timestamps {
             }
           } // stage('Unit Test')
 
-          // Integration tests are flaky in ci so skip for now - EH 15/10/2020
-          // stage('Integration Test') {
-          //   appc.install()
-          //   appc.installAndSelectSDK(sdkVersion)
-          //   appc.loggedIn {
-          //     // Run ui/e2e tests
-          //     try {
-          //       sh './runUITests.sh'
-          //     } finally {
-          //       sh 'ls'
-          //       junit 'junit_report-ui.xml'
-          //     }
-          //   }
-          // } // stage('Integration Test')
-
           stage('Build vsix') {
             // Create the vsix package
             sh 'npx vsce package'

--- a/package.json
+++ b/package.json
@@ -918,7 +918,7 @@
     "lint": "eslint src/ scripts/",
     "release": "npm run generate-docs && standard-version && npx vsce package",
     "test": "cross-env COVERAGE=1 node ./out/test/unit/runTest.js",
-    "test:integration": "node -e \"console.log('Hey there! You want to run the UI tests, but you cant do that via npm run. So you want to run ./runUITests.sh')\"",
+    "test:integration": "npm run compile && node ./out/test/integration/runTests.js",
     "vscode:prepublish": "npm run compile",
     "pretest": "npm run compile",
     "watch": "tsc -watch -p ./",

--- a/runUITests.sh
+++ b/runUITests.sh
@@ -1,5 +1,0 @@
-#! /usr/bin/env sh
-
-# npm scripts are run as "nobody" which screws up the extensions detection of the appc cli
-# So, run via this shell script
-node ./out/test/integration/runTests.js

--- a/src/test/integration/.mocharc.ts
+++ b/src/test/integration/.mocharc.ts
@@ -1,13 +1,4 @@
-import * as path from 'path';
-const reportPath = path.join(__dirname, '..', '..', '..', 'junit_report-ui.xml');
-
 module.exports = {
-	reporter: 'mocha-multi-reporters',
-	reporterOptions: {
-		reporterEnabled: 'mocha-jenkins-reporter, spec',
-		mochaJenkinsReporterReporterOptions: {
-			junit_report_path: reportPath // eslint-disable-line @typescript-eslint/camelcase
-		}
-	},
+	reporter: 'spec',
 	retries: 3
 };

--- a/src/test/integration/fixtures/settings.json
+++ b/src/test/integration/fixtures/settings.json
@@ -1,0 +1,3 @@
+{
+	"titanium.general.useTi": true
+}

--- a/src/test/integration/runTests.ts
+++ b/src/test/integration/runTests.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as tmp from 'tmp';
 import { ExTester, ReleaseQuality } from 'vscode-extension-tester';
-import { testSetup } from './util/common';
+import { getFixturesDirectory, testSetup } from './util/common';
 
 async function main (): Promise<void> {
 	// We create a temporary directory for the "Extension directory" so that only our extension and
@@ -12,7 +12,8 @@ async function main (): Promise<void> {
 		await testSetup();
 		const tester = new ExTester(undefined, ReleaseQuality.Stable, tempDirectory.name);
 		const mochaConfig = path.join(__dirname, '.mocharc.js');
-		tester.setupAndRunTests('out/test/integration/suite/**/*.test.js', undefined, undefined, { config: mochaConfig });
+		const settings = path.join(getFixturesDirectory(), 'settings.json');
+		tester.setupAndRunTests('out/test/integration/suite/**/*.test.js', undefined, undefined, { config: mochaConfig, settings });
 	} finally {
 		fs.removeSync(tempDirectory.name);
 	}

--- a/src/test/integration/runTests.ts
+++ b/src/test/integration/runTests.ts
@@ -10,10 +10,16 @@ async function main (): Promise<void> {
 	const tempDirectory = tmp.dirSync();
 	try {
 		await testSetup();
-		const tester = new ExTester(undefined, ReleaseQuality.Stable, tempDirectory.name);
+
+		// When setting the version to "insider" we want to actually use "latest" and then switch
+		// to the ReleaseQuality.Insider stream, not set the version as "insider"
+		const vsCodeVersion = (!process.env.CODE_VERSION || process.env.CODE_VERSION === 'insider') ? 'latest' : process.env.CODE_VERSION;
 		const mochaConfig = path.join(__dirname, '.mocharc.js');
 		const settings = path.join(getFixturesDirectory(), 'settings.json');
-		tester.setupAndRunTests('out/test/integration/suite/**/*.test.js', undefined, undefined, { config: mochaConfig, settings });
+		const releaseQuality = process.env.CODE_VERSION === 'insider' ? ReleaseQuality.Insider : ReleaseQuality.Stable;
+
+		const tester = new ExTester(undefined, releaseQuality, tempDirectory.name);
+		tester.setupAndRunTests('out/test/integration/suite/**/*.test.js', vsCodeVersion, undefined, { config: mochaConfig, settings });
 	} finally {
 		fs.removeSync(tempDirectory.name);
 	}

--- a/src/test/integration/suite/alloy/generate.test.ts
+++ b/src/test/integration/suite/alloy/generate.test.ts
@@ -8,7 +8,7 @@ import * as tmp from 'tmp';
 
 const projectDirectory = path.join(getFixturesDirectory(), 'alloy-project');
 
-describe('Alloy component generation', function () {
+describe.only('Alloy component generation', function () {
 	this.timeout(30000);
 
 	let browser: VSBrowser;
@@ -17,7 +17,7 @@ describe('Alloy component generation', function () {
 	let tempDirectory: tmp.DirResult;
 
 	before(async function () {
-		this.timeout(120000);
+		this.timeout(180000);
 		browser = VSBrowser.instance;
 		driver = browser.driver;
 		const editorView = new EditorView();

--- a/src/test/integration/suite/alloy/generate.test.ts
+++ b/src/test/integration/suite/alloy/generate.test.ts
@@ -16,7 +16,8 @@ describe('Alloy component generation', function () {
 	let generator: AlloyGenerate;
 	let tempDirectory: tmp.DirResult;
 
-	beforeEach(async function () {
+	before(async function () {
+		this.timeout(120000);
 		browser = VSBrowser.instance;
 		driver = browser.driver;
 		const editorView = new EditorView();
@@ -26,11 +27,12 @@ describe('Alloy component generation', function () {
 		generator = new AlloyGenerate(driver);
 		tempDirectory = tmp.dirSync();
 		await copy(projectDirectory, tempDirectory.name);
+		await generator.waitForGetStarted();
 		await generator.openFolder(tempDirectory.name);
 		await generator.waitForEnvironmentDetectionCompletion();
 	});
 
-	afterEach(async function () {
+	after(async function () {
 		if (tempDirectory) {
 			await remove(tempDirectory.name);
 		}
@@ -38,28 +40,28 @@ describe('Alloy component generation', function () {
 
 	// alloy generate controller creates all 3 files
 	it('should be able to generate a controller and related files', async function () {
-		await generator.generateComponent('controller', 'test');
+		await generator.generateComponent('controller', 'test1');
 
 		for (const [ folder, fileType ] of Object.entries({ controllers: '.js', styles: '.tss', views: '.xml' })) {
-			const file = path.join(tempDirectory.name, 'app', folder, `test${fileType}`);
+			const file = path.join(tempDirectory.name, 'app', folder, `test1${fileType}`);
 			expect(pathExistsSync(file)).to.equal(true, `${file} did not exist`);
 		}
 	});
 
 	// alloy generate style only creates a style
 	it('should be able to generate a style', async function () {
-		await generator.generateComponent('style', 'test');
+		await generator.generateComponent('style', 'test2');
 
-		const file = path.join(tempDirectory.name, 'app', 'styles', 'test.tss');
+		const file = path.join(tempDirectory.name, 'app', 'styles', 'test2.tss');
 		expect(pathExistsSync(file)).to.equal(true, `${file} did not exist`);
 	});
 
 	// alloy generate view generates view and a style
 	it('should be able to generate a view and related files', async function () {
-		await generator.generateComponent('view', 'test');
+		await generator.generateComponent('view', 'test3');
 
 		for (const [ folder, fileType ] of Object.entries({ styles: '.tss', views: '.xml' })) {
-			const file = path.join(tempDirectory.name, 'app', folder, `test${fileType}`);
+			const file = path.join(tempDirectory.name, 'app', folder, `test3${fileType}`);
 			expect(pathExistsSync(file)).to.equal(true, `${file} did not exist`);
 		}
 	});

--- a/src/test/integration/suite/alloy/generate.test.ts
+++ b/src/test/integration/suite/alloy/generate.test.ts
@@ -8,7 +8,7 @@ import * as tmp from 'tmp';
 
 const projectDirectory = path.join(getFixturesDirectory(), 'alloy-project');
 
-describe.only('Alloy component generation', function () {
+describe('Alloy component generation', function () {
 	this.timeout(30000);
 
 	let browser: VSBrowser;

--- a/src/test/integration/suite/create/app.test.ts
+++ b/src/test/integration/suite/create/app.test.ts
@@ -7,7 +7,7 @@ import * as xml2js from 'xml2js';
 import { parsePlatformsFromTiapp, dismissNotifications } from '../../util/common';
 import { ProjectCreator } from '../../util/create';
 
-(process.env.JENKINS ? describe.skip : describe)('Application creation', function () {
+describe('Application creation', function () {
 	this.timeout(30000);
 
 	let browser: VSBrowser;
@@ -15,7 +15,8 @@ import { ProjectCreator } from '../../util/create';
 	let tempDirectory: tmp.DirResult;
 	let creator: ProjectCreator;
 
-	beforeEach(async function () {
+	before(async function () {
+		this.timeout(180000);
 		browser = VSBrowser.instance;
 		driver = browser.driver;
 		const editorView = new EditorView();
@@ -24,7 +25,7 @@ import { ProjectCreator } from '../../util/create';
 		tempDirectory = tmp.dirSync();
 		await dismissNotifications();
 		creator = new ProjectCreator(driver);
-		await creator.waitForEnvironmentDetectionCompletion();
+		await creator.waitForGetStarted();
 	});
 
 	afterEach(async function () {
@@ -39,7 +40,6 @@ import { ProjectCreator } from '../../util/create';
 
 		await creator.createApp({
 			id: 'com.axway.e2e',
-			enableServices: false,
 			folder: tempDirectory.name,
 			name,
 			platforms: [ 'android', 'ios' ]
@@ -62,7 +62,6 @@ import { ProjectCreator } from '../../util/create';
 
 		await creator.createApp({
 			id: 'com.axway.e2e',
-			enableServices: false,
 			folder: tempDirectory.name,
 			name,
 			platforms: [ 'android' ]

--- a/src/test/integration/suite/create/module.test.ts
+++ b/src/test/integration/suite/create/module.test.ts
@@ -6,7 +6,7 @@ import * as tmp from 'tmp';
 import { ProjectCreator } from '../../util/create';
 import { dismissNotifications } from '../../util/common';
 
-(process.env.JENKINS ? describe.skip : describe)('Module creation', function () {
+describe('Module creation', function () {
 	this.timeout(30000);
 
 	let browser: VSBrowser;
@@ -14,7 +14,8 @@ import { dismissNotifications } from '../../util/common';
 	let driver: WebDriver;
 	let tempDirectory: tmp.DirResult;
 
-	beforeEach(async function () {
+	before(async function () {
+		this.timeout(180000);
 		browser = VSBrowser.instance;
 		driver = browser.driver;
 		const editorView = new EditorView();
@@ -23,7 +24,7 @@ import { dismissNotifications } from '../../util/common';
 		tempDirectory = tmp.dirSync();
 		await dismissNotifications();
 		creator = new ProjectCreator(driver);
-		await creator.waitForEnvironmentDetectionCompletion();
+		await creator.waitForGetStarted();
 	});
 
 	afterEach(async function () {

--- a/src/test/integration/types.ts
+++ b/src/test/integration/types.ts
@@ -7,7 +7,6 @@ export type Target = {
 
 export type AppCreateOptions = {
 	id: string;
-	enableServices: boolean;
 	folder: string;
 	name: string;
 	platforms: string[];

--- a/src/test/integration/util/common.ts
+++ b/src/test/integration/util/common.ts
@@ -222,7 +222,6 @@ export class CommonUICreator {
 					for (const choice of choices) {
 						items.push(await choice.getText());
 					}
-					console.log(items);
 
 					throw new Error(`It looks like you dont have tooling installed, you are missing ${items}`);
 				}

--- a/src/test/integration/util/common.ts
+++ b/src/test/integration/util/common.ts
@@ -179,6 +179,11 @@ export class CommonUICreator {
 						section = sec;
 						continue;
 					}
+
+					if (title.toLowerCase().includes('build')) {
+						// The extension is already up and running, so lets just continue on
+						return true;
+					}
 				}
 
 				if (!section || !section.isDisplayed()) {

--- a/src/test/integration/util/create.ts
+++ b/src/test/integration/util/create.ts
@@ -17,7 +17,6 @@ export class ProjectCreator extends CommonUICreator {
 		await this.setName(options.name);
 		await this.setId(options.id);
 		await this.setPlatforms(options.platforms);
-		await this.setEnableServices(options.enableServices);
 		await this.setFolder();
 
 		try {

--- a/src/test/integration/util/create.ts
+++ b/src/test/integration/util/create.ts
@@ -62,7 +62,7 @@ export class ProjectCreator extends CommonUICreator {
 			await InputBox.create();
 		} catch (error) {
 			// no! Lets wait some more, InputBox.create just waited 5 seconds for us too
-			await this.driver.sleep(10000);
+			await this.driver.sleep(20000);
 		}
 
 		await this.setName(options.name);

--- a/src/test/integration/util/create.ts
+++ b/src/test/integration/util/create.ts
@@ -58,6 +58,14 @@ export class ProjectCreator extends CommonUICreator {
 		// maybe we should just have a notification for it?
 		await this.driver.sleep(10000);
 
+		try {
+			// has info loaded yet?
+			await InputBox.create();
+		} catch (error) {
+			// no! Lets wait some more, InputBox.create just waited 5 seconds for us too
+			await this.driver.sleep(10000);
+		}
+
 		await this.setName(options.name);
 		await this.setId(options.id);
 		await this.setPlatforms(options.platforms);

--- a/src/updates/index.ts
+++ b/src/updates/index.ts
@@ -12,6 +12,7 @@ export async function installUpdates (updateInfo?: UpdateInfo[], promptForChoice
 		if (!updateInfo) {
 			progress.report({ message: 'Checking for latest updates' });
 			updateInfo = await ExtensionContainer.getUpdates();
+			progress.report({ message: 'Please select updates' });
 		}
 
 		if (promptForChoice) {


### PR DESCRIPTION
Moves the existing integration tests over to OSS tooling and gets them running in actions against the lowest supported VS Code, latest VS Code, and nightly VS Code