### PR TITLE
Improve packaging discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -658,6 +658,11 @@
           "group": "navigation@2"
         },
         {
+          "command": "titanium.package.run",
+          "when": "view == titanium.view.buildExplorer",
+          "group": "navigation@2"
+        },
+        {
           "command": "titanium.build.setLiveViewEnabled",
           "when": "view == titanium.view.buildExplorer && !config.titanium.build.liveview",
           "group": "navigation@3"
@@ -696,11 +701,11 @@
       "view/item/context": [
         {
           "command": "titanium.package.run",
-          "when": "view == titanium.view.buildExplorer && viewItem == PlatformNode"
+          "when": "view == titanium.view.buildExplorer && viewItem =~ /PlatformNode|DistributeNode/"
         },
         {
           "command": "titanium.package.run",
-          "when": "view == titanium.view.buildExplorer && viewItem == PlatformNode",
+          "when": "view == titanium.view.buildExplorer && viewItem =~ /PlatformNode|DistributeNode/",
           "group": "inline"
         },
         {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -43,7 +43,11 @@ export function registerCommands (): void {
 		}
 	});
 
-	registerCommand(Commands.Package, node => {
+	registerCommand(Commands.Package, async (node) => {
+		if (ExtensionContainer.context.globalState.get<boolean>(GlobalState.Running)) {
+			await vscode.commands.executeCommand(Commands.StopBuild);
+			await sleep(100);
+		}
 		if (project.isTitaniumApp) {
 			return packageApplication(node);
 		} else if (project.isTitaniumModule) {

--- a/src/explorer/nodes/baseNode.ts
+++ b/src/explorer/nodes/baseNode.ts
@@ -1,12 +1,12 @@
 import { TreeItem, TreeItemCollapsibleState } from 'vscode';
-import { DevelopmentTarget } from '../../types/cli';
+import { Target } from '../../types/cli';
 export abstract class BaseNode implements TreeItem {
 
 	public abstract readonly collapsibleState: TreeItemCollapsibleState;
 	public abstract readonly contextValue: string;
 	public readonly deviceId: string | undefined;
 	public readonly label: string;
-	public readonly targetId?: DevelopmentTarget;
+	public readonly targetId?: Target;
 	public readonly version?: string | undefined;
 	constructor (label: string) {
 		this.label = label;

--- a/src/explorer/nodes/distributeNode.ts
+++ b/src/explorer/nodes/distributeNode.ts
@@ -1,0 +1,24 @@
+import { BaseNode } from './baseNode';
+
+import { TreeItemCollapsibleState } from 'vscode';
+import { Platform } from '../../types/common';
+import { DeploymentTarget } from '../../types/cli';
+
+export class DistributeNode extends BaseNode {
+
+	public readonly collapsibleState = TreeItemCollapsibleState.None;
+	public readonly contextValue: string = 'DistributeNode';
+
+	constructor (
+		public readonly label: string,
+		public readonly platform: Platform,
+		public readonly target: string,
+		public readonly targetId: DeploymentTarget
+	) {
+		super(label);
+	}
+
+	get tooltip (): string {
+		return this.label;
+	}
+}

--- a/src/explorer/nodes/platformNode.ts
+++ b/src/explorer/nodes/platformNode.ts
@@ -4,6 +4,7 @@ import { TargetNode } from './targetNode';
 import { TreeItemCollapsibleState } from 'vscode';
 import { Platform, PlatformPretty } from '../../types/common';
 import { nameForPlatform } from '../../utils';
+import { DistributeNode } from './distributeNode';
 
 export class PlatformNode extends BaseNode {
 
@@ -19,17 +20,21 @@ export class PlatformNode extends BaseNode {
 		this.contextValue = 'PlatformNode';
 	}
 
-	public getChildren (): TargetNode[] {
+	public getChildren (): Array<DistributeNode|TargetNode> {
 		switch (this.platform) {
 			case 'android':
 				return [
 					new TargetNode('Device', this.platform),
-					new TargetNode('Emulator', this.platform)
+					new TargetNode('Emulator', this.platform),
+					new DistributeNode('Play Store', this.platform, this.label, 'dist-playstore')
 				];
 			case 'ios':
 				return [
 					new TargetNode('Device', this.platform),
-					new TargetNode('Simulator', this.platform)
+					new TargetNode('Simulator', this.platform),
+					new DistributeNode('Ad Hoc', this.platform, this.label, 'dist-adhoc'),
+					new DistributeNode('App Store', this.platform, this.label, 'dist-appstore')
+
 				];
 			default:
 				return [];

--- a/src/explorer/nodes/targetNode.ts
+++ b/src/explorer/nodes/targetNode.ts
@@ -1,6 +1,7 @@
 import { TreeItemCollapsibleState } from 'vscode';
 import { BaseNode } from './baseNode';
 import { DeviceNode } from './deviceNode';
+import { DistributeNode } from './distributeNode';
 import { OSVerNode } from './osVerNode';
 
 import appc from '../../appc';
@@ -51,6 +52,10 @@ export class TargetNode extends BaseNode {
 						devices.push(new DeviceNode(label, this.platform, this.label, device.udid, this.targetId));
 					}
 					break;
+				case 'Package':
+					devices.push(new DistributeNode('Adhoc', this.platform, this.label, 'dist-adhoc'));
+					devices.push(new DistributeNode('App Store', this.platform, this.label, 'dist-appstore'));
+					break;
 			}
 		} else if (this.platform === 'android') {
 			switch (this.label) {
@@ -69,6 +74,9 @@ export class TargetNode extends BaseNode {
 							devices.push(new DeviceNode(label, this.platform, this.label, emulator.id, this.targetId));
 						}
 					}
+					break;
+				case 'Package':
+					devices.push(new DistributeNode('Play Store', this.platform, this.label, 'dist-playstore'));
 					break;
 			}
 		}

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -80,8 +80,8 @@ export interface CleanAppOptions extends BaseCLIOptions {
 	projectDir: string;
 }
 
-export type Target = DevelopmentTarget | DeploymenTarget;
+export type Target = DevelopmentTarget | DeploymentTarget;
 
 export type DevelopmentTarget = 'device' | 'emulator' | 'simulator';
 
-export type DeploymenTarget = 'dist-adhoc' | 'dist-appstore' | 'dist-playstore';
+export type DeploymentTarget = 'dist-adhoc' | 'dist-appstore' | 'dist-playstore';


### PR DESCRIPTION
This PR attempts to improve the discoverability of packing by doing the following from #642

* Add a top level Package button alongside the Run button in the title bar of the Build Explorer
* Add a new Package sub-item to each platform in the Build Explorer that will list the possible distribution target

The second on is _slightly_ different in that each packaging target is listed individually rather than under a `Package` option. This was chosen because: 

* Although there are 2 options for iOS, Android only has one so it felt awkward
* The semantics fit better, emulator/simulator are targets (--target on the CLI), so (personally) it made sense to list the other targets alongside them


This is what the changes look like 
![Build menu with packaging improvements](https://user-images.githubusercontent.com/8705251/118662575-06d74900-b7e8-11eb-9966-b6c2f84dc7da.png)
