### PR TITLE
Improve build recall

### DIFF
--- a/src/commands/buildApp.ts
+++ b/src/commands/buildApp.ts
@@ -2,42 +2,12 @@ import * as vscode from 'vscode';
 import { DeviceNode, OSVerNode, PlatformNode, TargetNode } from '../explorer/nodes';
 import { checkLogin, handleInteractionError, InteractionError } from './common';
 import { selectPlatform } from '../quickpicks';
-import { getBuildTask, Platform } from '../tasks/tasksHelper';
-import { AppBuildTask, AppBuildTaskTitaniumBuildBase } from '../tasks/buildTaskProvider';
+import { getBuildTask } from '../tasks/tasksHelper';
+import { AppBuildTask } from '../tasks/buildTaskProvider';
 import { ExtensionContainer } from '../container';
 import { WorkspaceState } from '../constants';
-import { nameForPlatform, nameForTarget } from '../utils';
-import appc from '../appc';
-
-function getDeviceNameFromId (deviceID: string, platform: Platform, target: string): string {
-	let deviceName: string|undefined;
-	if (platform === 'android' && target === 'device') {
-		deviceName = (appc.androidDevices().find(device => device.id === deviceID))?.name;
-	} else if (platform === 'android' && target === 'emulator') {
-		deviceName = (appc.androidEmulators().AVDs.find(emulator => emulator.id === deviceID))?.name;
-	} else if (platform === 'ios' && target === 'device') {
-		deviceName = (appc.iOSDevices().find(device => device.udid === deviceID))?.name;
-	} else if (platform === 'ios' && target === 'simulator') {
-		for (const simVer of appc.iOSSimulatorVersions()) {
-			deviceName = (appc.iOSSimulators()[simVer].find(simulator => simulator.udid === deviceID))?.name;
-			if (deviceName) {
-				deviceName = `${deviceName} (${simVer})`;
-				break;
-			}
-		}
-	}
-
-	if (!deviceName) {
-		throw new Error(`Unable to find a name for ${deviceID}`);
-	}
-
-	return deviceName;
-}
-
-interface LastBuildState extends AppBuildTaskTitaniumBuildBase {
-	deviceId: string;
-	target: 'device' | 'emulator' | 'simulator';
-}
+import { getDeviceNameFromId, nameForPlatform, nameForTarget } from '../utils';
+import { LastBuildState, Platform } from '../types/common';
 
 export async function buildApplication (node?: DeviceNode | OSVerNode | PlatformNode | TargetNode): Promise<void> {
 	try {

--- a/src/commands/buildModule.ts
+++ b/src/commands/buildModule.ts
@@ -3,8 +3,9 @@ import { DeviceNode, OSVerNode, PlatformNode, TargetNode } from '../explorer/nod
 import { checkLogin, handleInteractionError, InteractionError } from './common';
 
 import { selectPlatform } from '../quickpicks/common';
-import { getBuildTask, Platform } from '../tasks/tasksHelper';
+import { getBuildTask } from '../tasks/tasksHelper';
 import { BuildTask } from '../tasks/buildTaskProvider';
+import { Platform } from '../types/common';
 
 export async function buildModule (node?: DeviceNode | OSVerNode | PlatformNode | TargetNode): Promise<void> {
 	try {

--- a/src/commands/packageApp.ts
+++ b/src/commands/packageApp.ts
@@ -3,11 +3,12 @@ import { DeviceNode, OSVerNode, PlatformNode, TargetNode } from '../explorer/nod
 import { checkLogin, handleInteractionError, InteractionError } from './common';
 
 import { selectPlatform } from '../quickpicks/common';
-import { Platform, getPackageTask } from '../tasks/tasksHelper';
+import { getPackageTask } from '../tasks/tasksHelper';
 import { ExtensionContainer } from '../container';
 import { WorkspaceState } from '../constants';
 import { nameForPlatform, nameForTarget } from '../utils';
 import { PackageTask, AppPackageTaskTitaniumBuildBase } from '../tasks/packageTaskProvider';
+import { Platform } from '../types/common';
 
 interface LastState extends AppPackageTaskTitaniumBuildBase {
 	target: 'dist-appstore' | 'dist-adhoc' | 'dist-playstore';

--- a/src/commands/packageModule.ts
+++ b/src/commands/packageModule.ts
@@ -3,8 +3,9 @@ import { DeviceNode, OSVerNode, PlatformNode, TargetNode } from '../explorer/nod
 import { checkLogin, handleInteractionError, InteractionError } from './common';
 
 import { selectPlatform } from '../quickpicks/common';
-import { Platform, getPackageTask } from '../tasks/tasksHelper';
+import { getPackageTask } from '../tasks/tasksHelper';
 import { PackageTask } from '../tasks/packageTaskProvider';
+import { Platform } from '../types/common';
 
 export async function packageModule (node: DeviceNode | OSVerNode | PlatformNode | TargetNode): Promise<void> {
 	try {

--- a/src/common/extensionProtocol.ts
+++ b/src/common/extensionProtocol.ts
@@ -1,6 +1,5 @@
 import { IAttachRequestArgs, ILaunchRequestArgs } from 'vscode-chrome-debug-core';
-import { LogLevel } from '../types/common';
-import { Platform } from '../tasks/tasksHelper';
+import { LogLevel, Platform } from '../types/common';
 import { AppBuildTaskTitaniumBuildBase } from '../tasks/buildTaskProvider';
 
 export interface Request {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,5 +29,6 @@ export enum WorkspaceState {
 	LastKeystorePath = 'lastKeystorePath',
 	LastCreationPath = 'lastCreationPath',
 	LastAndroidDebug = 'lastAndroidDebugOptions',
-	LastiOSDebug = 'lastiOSDebugOptions'
+	LastiOSDebug = 'lastiOSDebugOptions',
+	RecentBuilds = 'recentBuilds'
 }

--- a/src/explorer/nodes.ts
+++ b/src/explorer/nodes.ts
@@ -2,6 +2,7 @@ export * from './nodes/baseNode';
 export * from './nodes/blankNode';
 export * from './nodes/commandNode';
 export * from './nodes/deviceNode';
+export * from './nodes/distributeNode';
 export * from './nodes/osVerNode';
 export * from './nodes/platformNode';
 export * from './nodes/targetNode';

--- a/src/explorer/nodes/recentNode.ts
+++ b/src/explorer/nodes/recentNode.ts
@@ -1,0 +1,73 @@
+import { BaseNode } from './baseNode';
+
+import { TreeItemCollapsibleState } from 'vscode';
+import { ExtensionContainer } from '../../container';
+import { DeviceNode } from './deviceNode';
+import { getDeviceNameFromId, nameForPlatform, nameForTarget } from '../../utils';
+import { Platform as NewPlatform } from '../../types/common';
+import { BlankNode } from './blankNode';
+import { isDistributionAppBuild } from '../../tasks/tasksHelper';
+import { GlobalState } from '../../constants';
+import { DistributeNode } from './distributeNode';
+
+export class RecentNode extends BaseNode {
+
+	public readonly collapsibleState = TreeItemCollapsibleState.Expanded;
+	public readonly contextValue: string = 'RecentNode';
+	public readonly label = 'Recent';
+
+	public getChildren (): Array<BlankNode | DeviceNode> {
+		const recentBuildNodes: Array<BlankNode | DeviceNode> = [];
+
+		// If we're refreshing hold off on populating this list so that we don't error when creating
+		// the pretty name
+		const refreshingEnvironment = ExtensionContainer.context.globalState.get<boolean>(GlobalState.RefreshEnvironment);
+		if (refreshingEnvironment) {
+			return [ new BlankNode('Refreshing environment') ];
+		}
+
+		for (const [ , build ] of ExtensionContainer.recentBuilds) {
+			if (!build) {
+				continue;
+			}
+
+			if (isDistributionAppBuild(build)) {
+				if (!build.target) {
+					continue;
+				}
+
+				try {
+					const nodeLabel = `${nameForPlatform(build.platform)} ${nameForTarget(build.target)}`;
+					recentBuildNodes.push(new DistributeNode(nodeLabel, build.platform, nameForTarget(build.target), build.target));
+				} catch (error) {
+					// ignore errors as this might be down to the environment changing so this is now an invalid state
+				}
+
+			} else {
+				if (!build.deviceId || !build.target) {
+					continue;
+				}
+				try {
+					const deviceName = getDeviceNameFromId(build.deviceId, build.platform, build.target);
+					const lastBuildDescription = `${nameForPlatform(build.platform)} ${nameForTarget(build.target)} ${deviceName}`;
+
+					recentBuildNodes.push(new DeviceNode(lastBuildDescription, build.platform as NewPlatform, build.target, build.deviceId, build.target));
+				} catch (error) {
+					// ignore errors as this might be down to the environment changing so this is now an invalid state
+				}
+
+			}
+		}
+
+		if (!recentBuildNodes.length) {
+			recentBuildNodes.push(new BlankNode('No recent builds'));
+		}
+
+		// reverse the order so we display the most recent at the top
+		return recentBuildNodes.reverse();
+	}
+
+	get tooltip (): string {
+		return this.label;
+	}
+}

--- a/src/explorer/tiExplorer.ts
+++ b/src/explorer/tiExplorer.ts
@@ -3,6 +3,7 @@ import appc from '../appc';
 import { Platform } from '../types/common';
 import { platforms } from '../utils';
 import { BaseNode, PlatformNode } from './nodes';
+import { RecentNode } from './nodes/recentNode';
 
 export default class DeviceExplorer implements vscode.TreeDataProvider<BaseNode> {
 
@@ -12,6 +13,7 @@ export default class DeviceExplorer implements vscode.TreeDataProvider<BaseNode>
 	public readonly onDidChangeTreeData: vscode.Event<BaseNode|undefined> = this._onDidChangeTreeData.event;
 
 	private platforms: Map<string, PlatformNode> = new Map();
+	private recentNode = new RecentNode('Recent Builds');
 
 	public async refresh (): Promise<void> {
 		return vscode.window.withProgress({ location: vscode.ProgressLocation.Window, title: 'Reading Appcelerator environment ...' }, async () => {
@@ -27,6 +29,10 @@ export default class DeviceExplorer implements vscode.TreeDataProvider<BaseNode>
 				return Promise.reject();
 			}
 		});
+	}
+
+	public refreshRecentBuilds (): void {
+		this._onDidChangeTreeData.fire(this.recentNode);
 	}
 
 	public getTreeItem (element: BaseNode): vscode.TreeItem {
@@ -45,6 +51,8 @@ export default class DeviceExplorer implements vscode.TreeDataProvider<BaseNode>
 			this.platforms.set(platform, node);
 			elements.push(node);
 		}
+
+		elements.push(this.recentNode);
 		return Promise.resolve(elements);
 	}
 }

--- a/src/tasks/buildTaskProvider.ts
+++ b/src/tasks/buildTaskProvider.ts
@@ -2,10 +2,11 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { CommandTaskProvider, TitaniumTaskBase, TitaniumTaskDefinitionBase, TitaniumBuildBase } from './commandTaskProvider';
 import { selectBuildTarget } from '../quickpicks/build/common';
-import { TaskExecutionContext, Platform, debugSessionInformation, DEBUG_SESSION_VALUE } from './tasksHelper';
+import { TaskExecutionContext, debugSessionInformation, DEBUG_SESSION_VALUE } from './tasksHelper';
 import { Helpers } from './helpers/';
 import { platforms } from '../utils';
 import { TaskPseudoTerminal } from './taskPseudoTerminal';
+import { Platform } from '../types/common';
 
 export interface BuildTask extends TitaniumTaskBase {
 	definition: BuildTaskDefinitionBase;

--- a/src/tasks/commandTaskProvider.ts
+++ b/src/tasks/commandTaskProvider.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode';
-import { TaskExecutionContext, Platform, ProjectType } from './tasksHelper';
+import { TaskExecutionContext, ProjectType } from './tasksHelper';
 import { TaskPseudoTerminal } from './taskPseudoTerminal';
 import { TaskHelper, Helpers } from './helpers';
 import { UserCancellation, handleInteractionError, InteractionError, checkLogin } from '../commands/common';
-import { LogLevel } from '../types/common';
+import { LogLevel, Platform } from '../types/common';
 import { CommandError } from '../common/utils';
 
 function getPlatform (task: TitaniumTaskBase): Platform {

--- a/src/tasks/helpers/index.ts
+++ b/src/tasks/helpers/index.ts
@@ -1,6 +1,5 @@
+import { Platform } from '../../types/common';
 import { TaskHelper } from './base';
-import { Platform } from '../tasksHelper';
-
 export * from './android';
 export * from './base';
 export * from './ios';

--- a/src/tasks/packageTaskProvider.ts
+++ b/src/tasks/packageTaskProvider.ts
@@ -4,6 +4,7 @@ import { CommandTaskProvider, TitaniumTaskBase, TitaniumTaskDefinitionBase, Tita
 import { Helpers } from './helpers';
 import { TaskExecutionContext } from './tasksHelper';
 import { selectDistributionTarget } from '../quickpicks/build/common';
+import { DeploymentTarget } from '../types/cli';
 
 export interface PackageTask extends TitaniumTaskBase {
 	definition: PackageTaskDefinitionBase;
@@ -22,7 +23,7 @@ export interface ModulePackageTaskTitaniumBuildBase extends PackageTaskTitaniumB
 }
 
 export interface AppPackageTaskTitaniumBuildBase extends PackageTaskTitaniumBuildBase {
-	target?: 'dist-appstore' | 'dist-adhoc' | 'dist-playstore';
+	target?: DeploymentTarget;
 	projectType?: 'app';
 }
 

--- a/src/tasks/tasksHelper.ts
+++ b/src/tasks/tasksHelper.ts
@@ -8,8 +8,6 @@ import { TitaniumTaskBase, TitaniumTaskDefinitionBase } from './commandTaskProvi
 import { DeviceNode } from '../explorer/nodes';
 
 export type TitaniumTaskTypes = 'titanium-build' | 'titanium-package';
-
-export type Platform = 'android' | 'ios';
 export type ProjectType = 'app' | 'module';
 
 export interface RunningTask {

--- a/src/tasks/tasksHelper.ts
+++ b/src/tasks/tasksHelper.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { BuildTaskProvider, AppBuildTaskTitaniumBuildBase } from './buildTaskProvider';
 import { TaskPseudoTerminal } from './taskPseudoTerminal';
 import { androidHelper, iOSHelper, Helpers } from './helpers';
-import { PackageTaskProvider } from './packageTaskProvider';
+import { AppPackageTaskTitaniumBuildBase, PackageTaskProvider } from './packageTaskProvider';
 import { ExtensionContainer } from '../container';
 import { TitaniumTaskBase, TitaniumTaskDefinitionBase } from './commandTaskProvider';
 import { DeviceNode } from '../explorer/nodes';
@@ -92,4 +92,18 @@ export function getTasks <T extends TitaniumTaskDefinitionBase> (folder: string)
 	const allTasks = workspaceTasks && workspaceTasks.tasks as T[] || [];
 
 	return allTasks;
+}
+
+/**
+ * Determines whether a build definition is for an distribution build or not.
+ *
+ * @export
+ * @param {AppBuildTaskTitaniumBuildBase | AppPackageTaskTitaniumBuildBase} definition - The build definition
+ * @returns {Boolean}
+ */
+export function isDistributionAppBuild (definition: AppBuildTaskTitaniumBuildBase | AppPackageTaskTitaniumBuildBase): definition is AppPackageTaskTitaniumBuildBase {
+	if (definition.target?.startsWith('dist')) {
+		return true;
+	}
+	return false;
 }

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -1,5 +1,4 @@
-import { KeystoreInfo, LogLevel, Platform as PlatformEnum  } from './common';
-import { Platform } from '../tasks/tasksHelper';
+import { KeystoreInfo, LogLevel, Platform } from './common';
 import { CodeBase } from '../quickpicks/creation';
 
 export interface BaseCLIOptions {
@@ -43,7 +42,7 @@ export interface BuildModuleOptions extends BaseBuildOptions {
 
 export interface BasePackageOptions extends BaseCLIOptions {
 	outputDirectory: string;
-	platform: PlatformEnum;
+	platform: Platform;
 	projectDir: string;
 	target: string;
 }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,3 +1,4 @@
+import { AppBuildTaskTitaniumBuildBase } from '../tasks/buildTaskProvider';
 import { UpdateInfo } from 'titanium-editor-commons/updates';
 
 export interface KeystoreInfo {
@@ -51,13 +52,15 @@ export enum PlatformPretty {
 	ios = 'iOS'
 }
 
-export enum Platform {
-	android = 'android',
-	ios = 'ios'
-}
+export type Platform = 'android' | 'ios';
 
 export interface UpdateChoice extends Omit<UpdateInfo, 'hasUpdate' | 'releaseNotes'> {
 	label: string;
 	picked: boolean;
 	id: string;
+}
+
+export interface LastBuildState extends AppBuildTaskTitaniumBuildBase {
+	deviceId: string;
+	target: 'device' | 'emulator' | 'simulator';
 }


### PR DESCRIPTION
This PR implements the "Improving build recall" section of #643 by implementing a new node alongside the Android and iOS platforms that will list the 5 most recent builds like below
![Build explorer with a new "Recent" node](https://user-images.githubusercontent.com/8705251/118832894-eaefa800-b8b8-11eb-928f-3149b1d09448.png)