### PR TITLE
feat(tasks): support passing arguments as environment variables

### DIFF
--- a/src/commands/packageApp.ts
+++ b/src/commands/packageApp.ts
@@ -15,14 +15,14 @@ interface LastState extends AppPackageTaskTitaniumBuildBase {
 	target: DeploymentTarget;
 }
 
-function isDistributeNode(node: PlatformNode | DistributeNode): node is DistributeNode {
-	if (node.contextValue === 'DistributeNode') {
+function isDistributeNode(node?: PlatformNode | DistributeNode): node is DistributeNode {
+	if (node?.contextValue === 'DistributeNode') {
 		return true;
 	}
 	return false;
 }
 
-export async function packageApplication (node: PlatformNode | DistributeNode): Promise<void> {
+export async function packageApplication (node?: PlatformNode | DistributeNode): Promise<void> {
 	try {
 		checkLogin();
 

--- a/src/tasks/buildTaskProvider.ts
+++ b/src/tasks/buildTaskProvider.ts
@@ -7,6 +7,7 @@ import { Helpers } from './helpers/';
 import { platforms } from '../utils';
 import { TaskPseudoTerminal } from './taskPseudoTerminal';
 import { Platform } from '../types/common';
+import { Command } from './commandBuilder';
 
 export interface BuildTask extends TitaniumTaskBase {
 	definition: BuildTaskDefinitionBase;
@@ -87,7 +88,7 @@ export class BuildTaskProvider extends CommandTaskProvider {
 		);
 	}
 
-	public async resolveTaskInformation (context: TaskExecutionContext, task: BuildTask): Promise<string> {
+	public async resolveTaskInformation (context: TaskExecutionContext, task: BuildTask): Promise<Command> {
 		const { definition } = task;
 
 		if (!definition.titaniumBuild.projectDir) {

--- a/src/tasks/commandTaskProvider.ts
+++ b/src/tasks/commandTaskProvider.ts
@@ -5,6 +5,7 @@ import { TaskHelper, Helpers } from './helpers';
 import { UserCancellation, handleInteractionError, InteractionError, checkLogin } from '../commands/common';
 import { LogLevel, Platform } from '../types/common';
 import { CommandError } from '../common/utils';
+import { Command } from './commandBuilder';
 
 function getPlatform (task: TitaniumTaskBase): Platform {
 	if (task.definition.titaniumBuild.platform === 'android' || task.definition.titaniumBuild.android !== undefined) {
@@ -56,7 +57,7 @@ export abstract class CommandTaskProvider implements vscode.TaskProvider {
 		);
 	}
 
-	public abstract resolveTaskInformation (context: TaskExecutionContext, task: TitaniumTaskBase): Promise<string>
+	public abstract resolveTaskInformation (context: TaskExecutionContext, task: TitaniumTaskBase): Promise<Command>
 
 	public async executeTask (context: TaskExecutionContext, task: TitaniumTaskBase): Promise<number> {
 		// Use this as a centralized place to do things like login checks, analytics etc.

--- a/src/tasks/helpers/android.ts
+++ b/src/tasks/helpers/android.ts
@@ -1,5 +1,6 @@
 import { TaskExecutionContext, runningTasks } from '../tasksHelper';
 import { TaskHelper } from './base';
+import { Command } from '../commandBuilder';
 import { enterAndroidKeystoreInfo } from '../../quickpicks/build/android';
 import { KeystoreInfo } from '../../types/common';
 import { AppBuildTaskTitaniumBuildBase, BuildTaskDefinitionBase, BuildTaskTitaniumBuildBase } from '../buildTaskProvider';
@@ -28,7 +29,7 @@ export interface AndroidPackageTaskTitaniumBuildBase extends AppPackageTaskTitan
 
 export class AndroidHelper extends TaskHelper {
 
-	public async resolveAppBuildCommandLine (context: TaskExecutionContext, definition: AndroidBuildTaskTitaniumBuildBase): Promise<string> {
+	public async resolveAppBuildCommandLine (context: TaskExecutionContext, definition: AndroidBuildTaskTitaniumBuildBase): Promise<Command> {
 		const builder = this.createBuilder();
 
 		await this.resolveCommonAppOptions(context, definition, builder);
@@ -43,7 +44,7 @@ export class AndroidHelper extends TaskHelper {
 		return builder.resolve();
 	}
 
-	public async resolveAppPackageCommandLine(context: TaskExecutionContext, definition: AndroidPackageTaskTitaniumBuildBase): Promise<string> {
+	public async resolveAppPackageCommandLine(context: TaskExecutionContext, definition: AndroidPackageTaskTitaniumBuildBase): Promise<Command> {
 		const builder = this.createBuilder();
 
 		await this.resolveCommonPackagingOptions(context, definition, builder);
@@ -56,11 +57,11 @@ export class AndroidHelper extends TaskHelper {
 
 		builder
 			.addQuotedOption('--keystore', androidInfo.keystore.location)
-			.addOption('--alias', androidInfo.keystore.alias)
-			.addQuotedOption('--store-password', androidInfo.keystore.password);
+			.addQuotedOption('--alias', androidInfo.keystore.alias)
+			.addEnvironmentArgument('--store-password', androidInfo.keystore.password);
 
 		if (androidInfo.keystore.privateKeyPassword) {
-			builder.addQuotedOption('--key-password', androidInfo.keystore.privateKeyPassword);
+			builder.addEnvironmentArgument('--key-password', androidInfo.keystore.privateKeyPassword);
 		}
 
 		definition.android = androidInfo;
@@ -70,7 +71,7 @@ export class AndroidHelper extends TaskHelper {
 		return builder.resolve();
 	}
 
-	public async resolveModuleBuildCommandLine (context: TaskExecutionContext, definition: BuildTaskTitaniumBuildBase): Promise<string> {
+	public async resolveModuleBuildCommandLine (context: TaskExecutionContext, definition: BuildTaskTitaniumBuildBase): Promise<Command> {
 		const builder = this.createBuilder();
 
 		this.resolveCommonOptions(context, definition, builder);
@@ -78,7 +79,7 @@ export class AndroidHelper extends TaskHelper {
 		return builder.resolve();
 	}
 
-	public async resolveModulePackageCommandLine (context: TaskExecutionContext, definition: PackageTaskTitaniumBuildBase): Promise<string> {
+	public async resolveModulePackageCommandLine (context: TaskExecutionContext, definition: PackageTaskTitaniumBuildBase): Promise<Command> {
 		const builder = this.createBuilder();
 
 		this.resolveCommonOptions(context, definition, builder);

--- a/src/tasks/helpers/base.ts
+++ b/src/tasks/helpers/base.ts
@@ -1,5 +1,5 @@
 import { TaskExecutionContext, ProjectType, isDistributionAppBuild } from '../tasksHelper';
-import { CommandBuilder } from '../commandBuilder';
+import { Command, CommandBuilder } from '../commandBuilder';
 import { ExtensionContainer } from '../../container';
 import { quickPick } from '../../quickpicks';
 import * as fs from 'fs-extra';
@@ -32,11 +32,12 @@ function shouldEnableLiveview (definition: AppBuildTaskTitaniumBuildBase): boole
 
 export abstract class TaskHelper {
 
-	public abstract resolveAppBuildCommandLine (context: TaskExecutionContext, definition: BuildTaskTitaniumBuildBase): Promise<string>
-	public abstract resolveAppPackageCommandLine (context: TaskExecutionContext, definition: PackageTaskTitaniumBuildBase): Promise<string>
+	public abstract resolveAppBuildCommandLine (context: TaskExecutionContext, definition: BuildTaskTitaniumBuildBase): Promise<Command>
+	public abstract resolveAppPackageCommandLine (context: TaskExecutionContext,
+		definition: PackageTaskTitaniumBuildBase): Promise<Command>
 
-	public abstract resolveModuleBuildCommandLine (context: TaskExecutionContext, definition: BuildTaskTitaniumBuildBase): Promise<string>
-	public abstract resolveModulePackageCommandLine (context: TaskExecutionContext, definition: PackageTaskTitaniumBuildBase): Promise<string>
+	public abstract resolveModuleBuildCommandLine (context: TaskExecutionContext, definition: BuildTaskTitaniumBuildBase): Promise<Command>
+	public abstract resolveModulePackageCommandLine (context: TaskExecutionContext, definition: PackageTaskTitaniumBuildBase): Promise<Command>
 
 	public resolveCommonOptions (context: TaskExecutionContext, definition: TitaniumBuildBase, builder: CommandBuilder): void {
 

--- a/src/tasks/helpers/ios.ts
+++ b/src/tasks/helpers/ios.ts
@@ -4,6 +4,7 @@ import { getCorrectCertificateName } from '../../utils';
 import project from '../../project';
 import { IosCertificateType, IosCert } from '../../types/common';
 import { TaskHelper } from './base';
+import { Command } from '../commandBuilder';
 import { BuildTaskDefinitionBase, AppBuildTaskTitaniumBuildBase, BuildTaskTitaniumBuildBase } from '../buildTaskProvider';
 import { AppPackageTaskTitaniumBuildBase, PackageTaskDefinitionBase, PackageTaskTitaniumBuildBase } from '../packageTaskProvider';
 import { WorkspaceState } from '../../constants';
@@ -38,7 +39,7 @@ export interface IosPackageTaskTitaniumBuildBase extends AppPackageTaskTitaniumB
 }
 export class IosHelper extends TaskHelper {
 
-	public async resolveAppBuildCommandLine (context: TaskExecutionContext, definition: IosBuildTaskTitaniumBuildBase): Promise<string> {
+	public async resolveAppBuildCommandLine (context: TaskExecutionContext, definition: IosBuildTaskTitaniumBuildBase): Promise<Command> {
 		const builder = this.createBuilder();
 
 		await this.resolveCommonAppOptions(context, definition, builder);
@@ -81,7 +82,7 @@ export class IosHelper extends TaskHelper {
 		return builder.resolve();
 	}
 
-	public async resolveAppPackageCommandLine(context: TaskExecutionContext, definition: IosPackageTaskTitaniumBuildBase): Promise<string> {
+	public async resolveAppPackageCommandLine(context: TaskExecutionContext, definition: IosPackageTaskTitaniumBuildBase): Promise<Command> {
 		const builder = this.createBuilder();
 
 		await this.resolveCommonPackagingOptions(context, definition, builder);
@@ -120,7 +121,7 @@ export class IosHelper extends TaskHelper {
 		return builder.resolve();
 	}
 
-	public async resolveModuleBuildCommandLine (context: TaskExecutionContext, definition: BuildTaskTitaniumBuildBase): Promise<string> {
+	public async resolveModuleBuildCommandLine (context: TaskExecutionContext, definition: BuildTaskTitaniumBuildBase): Promise<Command> {
 		const builder = this.createBuilder();
 
 		this.resolveCommonOptions(context, definition, builder);
@@ -128,7 +129,7 @@ export class IosHelper extends TaskHelper {
 		return builder.resolve();
 	}
 
-	public async resolveModulePackageCommandLine (context: TaskExecutionContext, definition: PackageTaskTitaniumBuildBase): Promise<string> {
+	public async resolveModulePackageCommandLine (context: TaskExecutionContext, definition: PackageTaskTitaniumBuildBase): Promise<Command> {
 		const builder = this.createBuilder();
 
 		this.resolveCommonOptions(context, definition, builder);

--- a/src/tasks/packageTaskProvider.ts
+++ b/src/tasks/packageTaskProvider.ts
@@ -5,6 +5,7 @@ import { Helpers } from './helpers';
 import { TaskExecutionContext } from './tasksHelper';
 import { selectDistributionTarget } from '../quickpicks/build/common';
 import { DeploymentTarget } from '../types/cli';
+import { Command } from './commandBuilder';
 
 export interface PackageTask extends TitaniumTaskBase {
 	definition: PackageTaskDefinitionBase;
@@ -33,7 +34,7 @@ export class PackageTaskProvider extends CommandTaskProvider {
 		super('titanium-package', helpers);
 	}
 
-	public async resolveTaskInformation (context: TaskExecutionContext, task: PackageTask): Promise<string> {
+	public async resolveTaskInformation (context: TaskExecutionContext, task: PackageTask): Promise<Command> {
 		const { definition } = task;
 
 		if (!definition.titaniumBuild.projectDir) {

--- a/src/tasks/taskPseudoTerminal.ts
+++ b/src/tasks/taskPseudoTerminal.ts
@@ -5,6 +5,7 @@ import * as cp from 'child_process';
 import { ExtensionContainer } from '../container';
 import { GlobalState } from '../constants';
 import { CommandError } from '../common/utils';
+import { Command } from './commandBuilder';
 
 type StdListeners = (content: string) => void;
 
@@ -14,14 +15,15 @@ export enum EscapeCodes {
 	Yellow = '33m'
 }
 
-async function spawnCommand (command: string, options: cp.SpawnOptions, onStdout: StdListeners, onStderr: StdListeners, token?: vscode.CancellationToken): Promise<void> {
+async function spawnCommand (command: string, args: string[], options: cp.SpawnOptions, onStdout: StdListeners, onStderr: StdListeners, token?: vscode.CancellationToken): Promise<void> {
 	return new Promise((resolve, reject) => {
 		let cancellationListener: vscode.Disposable;
 		options = options || {};
 		options.shell = true;
 
-		const process = cp.spawn(command, [], options);
 		let output = '';
+		const process = cp.spawn(command, args, options);
+
 		process.stdout?.on('data', (data: Buffer) => {
 			const out = data.toString();
 			onStdout(out);
@@ -111,13 +113,17 @@ export class TaskPseudoTerminal implements vscode.Pseudoterminal {
 		}
 	}
 
-	public async executeCommand (command: string, folder: vscode.WorkspaceFolder, token?: vscode.CancellationToken): Promise<void> {
+	public async executeCommand (commandInfo: Command, folder: vscode.WorkspaceFolder, token?: vscode.CancellationToken): Promise<void> {
 
-		this.write(`${command} \r\n\r\n`);
+		const { args, command, environment }  = commandInfo;
+		const env = Object.assign(process.env, environment, { FORCE_COLOR: 1 });
+
+		this.write(`${command} ${args.join(' ')} \r\n\r\n`);
 
 		await spawnCommand(
 			command,
-			{ cwd: folder.uri.fsPath, env: { ...process.env, FORCE_COLOR: '1' } },
+			args,
+			{ cwd: folder.uri.fsPath, shell: true,  env },
 			(stdout: string) => {
 				this.write(stdout);
 			},


### PR DESCRIPTION
This has two benefits. Firstly, it allows us to avoid logging sensitive arguments like the keystore
password to the console, and secondly it allows it to support special characters in the keystore
password.

Closes EDITOR-66

Also fixes an issue when calling the package task not from a tree node