### PR TITLE
Support multi-root workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,7 +135,7 @@
         },
         "which": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "requires": {
             "isexe": "^2.0.0"
@@ -1161,6 +1161,31 @@
             "strip-bom": "^3.0.0"
           }
         },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
         "parse-json": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -1199,6 +1224,16 @@
           "requires": {
             "find-up": "^2.0.0",
             "read-pkg": "^2.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            }
           }
         },
         "require-main-filename": {
@@ -5362,7 +5397,7 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "resolved": false,
           "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
           "dev": true,
           "requires": {
@@ -5376,19 +5411,19 @@
           "dev": true
         },
         "@babel/highlight": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-          "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+          "version": "7.13.10",
+          "resolved": false,
+          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
+            "@babel/helper-validator-identifier": "^7.12.11",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           },
           "dependencies": {
             "chalk": {
               "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "resolved": false,
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "dev": true,
               "requires": {
@@ -5407,14 +5442,14 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.0",
+          "resolved": false,
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -5423,7 +5458,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "resolved": false,
               "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "dev": true,
               "requires": {
@@ -5432,7 +5467,7 @@
             },
             "supports-color": {
               "version": "7.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "resolved": false,
               "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "dev": true,
               "requires": {
@@ -5443,7 +5478,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -5452,13 +5487,13 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "resolved": false,
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "cross-spawn": {
           "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
@@ -5469,7 +5504,7 @@
         },
         "debug": {
           "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "resolved": false,
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
@@ -5483,9 +5518,9 @@
           "dev": true
         },
         "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "version": "2.0.0",
+          "resolved": false,
+          "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
           "dev": true
         },
         "fast-deep-equal": {
@@ -5496,37 +5531,42 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "ignore": {
           "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "resolved": false,
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": false,
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "path-key": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
         "regexpp": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+          "resolved": false,
           "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
           "dev": true
         },
         "shebang-command": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
@@ -5535,13 +5575,13 @@
         },
         "shebang-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
@@ -5550,7 +5590,7 @@
         },
         "strip-json-comments": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
         }
@@ -5603,6 +5643,34 @@
         "pkg-dir": "^2.0.0"
       },
       "dependencies": {
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
         "pkg-dir": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
@@ -5610,6 +5678,17 @@
           "dev": true,
           "requires": {
             "find-up": "^2.1.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+              "dev": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            }
           }
         }
       }
@@ -5679,6 +5758,34 @@
             "strip-bom": "^3.0.0"
           }
         },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
         "parse-json": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -5722,6 +5829,17 @@
           "requires": {
             "find-up": "^2.0.0",
             "read-pkg": "^2.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+              "dev": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            }
           }
         },
         "resolve": {
@@ -6385,11 +6503,19 @@
       "dev": true
     },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        }
       }
     },
     "findup-sync": {
@@ -9225,12 +9351,11 @@
       }
     },
     "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^5.0.0"
       }
     },
     "lock-verify": {
@@ -11356,19 +11481,19 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "requires": {
-        "p-try": "^1.0.0"
+        "yocto-queue": "^0.1.0"
       }
     },
     "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "^3.0.2"
       }
     },
     "p-map": {
@@ -12148,6 +12273,45 @@
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        }
       }
     },
     "readable-stream": {
@@ -14548,12 +14712,12 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "mkdirp": {
           "version": "0.5.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "requires": {
             "minimist": "^1.2.5"
@@ -15147,8 +15311,7 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -982,6 +982,7 @@
   },
   "dependencies": {
     "@awam/remotedebug-ios-webkit-adapter": "^0.4.3",
+    "find-up": "^5.0.0",
     "fs-extra": "^10.0.0",
     "get-port": "^5.1.1",
     "got": "^9.6.0",

--- a/src/appc.ts
+++ b/src/appc.ts
@@ -219,7 +219,7 @@ export class Appc {
 
 	public iOSSimulatorVersions (): string[] {
 		const sims = this.iOSSimulators();
-		return Object.keys(sims).sort((a, b) => semver.compare(semver.coerce(a)!, semver.coerce(b)!)).reverse();
+		return Object.keys(sims).sort((a, b) => semver.compare(semver.coerce(a) || a, semver.coerce(b) || b)).reverse();
 	}
 
 	/**

--- a/src/commands/alloyGenerate.ts
+++ b/src/commands/alloyGenerate.ts
@@ -6,6 +6,7 @@ import { window, workspace } from 'vscode';
 import { inputBox, quickPick } from '../quickpicks';
 import { capitalizeFirstLetter } from '../utils';
 import { UserCancellation } from './common';
+import { promptForWorkspaceFolder } from '../quickpicks/common';
 
 export enum AlloyModelAdapterType {
 	Properties = 'properties',
@@ -42,7 +43,8 @@ async function promptForDetails (type: AlloyComponentType, folder: AlloyComponen
 Promise<{ cwd: string; filePaths: string[]; name: string; type: AlloyComponentType }> {
 	const name = await inputBox({ prompt: `Enter the name for your ${type}` });
 
-	const cwd = workspace.rootPath!;
+	const { folder: workspaceFolder } = await promptForWorkspaceFolder();
+	const cwd = workspaceFolder.uri.fsPath;
 	const mainFile = path.join(cwd, 'app', folder, `${name}${extension}`);
 	const filePaths = [];
 	if (type === AlloyComponentType.Widget) {

--- a/src/commands/buildApp.ts
+++ b/src/commands/buildApp.ts
@@ -8,8 +8,9 @@ import { ExtensionContainer } from '../container';
 import { WorkspaceState } from '../constants';
 import { getDeviceNameFromId, nameForPlatform, nameForTarget } from '../utils';
 import { LastBuildState, Platform } from '../types/common';
+import { promptForWorkspaceFolder } from '../quickpicks/common';
 
-export async function buildApplication (node?: DeviceNode | OSVerNode | PlatformNode | TargetNode): Promise<void> {
+export async function buildApplication (node?: DeviceNode | OSVerNode | PlatformNode | TargetNode, folder?: vscode.WorkspaceFolder): Promise<void> {
 	try {
 		checkLogin();
 
@@ -28,8 +29,11 @@ export async function buildApplication (node?: DeviceNode | OSVerNode | Platform
 			}
 		}
 
-		const buildChoice = node?.platform as string || (await selectPlatform(lastBuildDescription)).id;
+		if (!folder) {
+			folder = (await promptForWorkspaceFolder()).folder;
+		}
 
+		const buildChoice = node?.platform as string || (await selectPlatform(lastBuildDescription)).id;
 		const platform = buildChoice === 'last' ? lastBuildState?.platform as Platform : buildChoice as Platform;
 
 		const taskDefinition: AppBuildTask = {
@@ -37,7 +41,7 @@ export async function buildApplication (node?: DeviceNode | OSVerNode | Platform
 				titaniumBuild: {
 					projectType: 'app',
 					platform,
-					projectDir: vscode.workspace.rootPath!
+					projectDir: folder.uri.fsPath
 				},
 				type: 'titanium-build',
 				name: `Build ${platform}`

--- a/src/commands/buildApp.ts
+++ b/src/commands/buildApp.ts
@@ -33,6 +33,7 @@ export async function buildApplication (node?: DeviceNode | OSVerNode | Platform
 			folder = (await promptForWorkspaceFolder()).folder;
 		}
 
+		const projectDir = folder.uri.fsPath;
 		const buildChoice = node?.platform as string || (await selectPlatform(lastBuildDescription)).id;
 		const platform = buildChoice === 'last' ? lastBuildState?.platform as Platform : buildChoice as Platform;
 
@@ -41,7 +42,7 @@ export async function buildApplication (node?: DeviceNode | OSVerNode | Platform
 				titaniumBuild: {
 					projectType: 'app',
 					platform,
-					projectDir: folder.uri.fsPath
+					projectDir
 				},
 				type: 'titanium-build',
 				name: `Build ${platform}`
@@ -52,11 +53,12 @@ export async function buildApplication (node?: DeviceNode | OSVerNode | Platform
 			presentationOptions: {},
 			problemMatchers: [],
 			runOptions: {},
-			scope: vscode.TaskScope.Workspace
+			scope: folder
 		};
 
 		if (buildChoice === 'last') {
-			Object.assign(taskDefinition.definition.titaniumBuild, lastBuildState);
+			// copy over the details from the last build, setting projectDir to the newly selected one
+			Object.assign(taskDefinition.definition.titaniumBuild, lastBuildState, { projectDir });
 		} else {
 			if (node?.targetId) {
 				taskDefinition.definition.titaniumBuild.target = node.targetId as 'device' | 'emulator' | 'simulator';

--- a/src/commands/buildModule.ts
+++ b/src/commands/buildModule.ts
@@ -2,14 +2,18 @@ import * as vscode from 'vscode';
 import { DeviceNode, OSVerNode, PlatformNode, TargetNode } from '../explorer/nodes';
 import { checkLogin, handleInteractionError, InteractionError } from './common';
 
-import { selectPlatform } from '../quickpicks/common';
+import { promptForWorkspaceFolder, selectPlatform } from '../quickpicks/common';
 import { getBuildTask } from '../tasks/tasksHelper';
 import { BuildTask } from '../tasks/buildTaskProvider';
 import { Platform } from '../types/common';
 
-export async function buildModule (node?: DeviceNode | OSVerNode | PlatformNode | TargetNode): Promise<void> {
+export async function buildModule (node?: DeviceNode | OSVerNode | PlatformNode | TargetNode, folder?: vscode.WorkspaceFolder): Promise<void> {
 	try {
 		checkLogin();
+
+		if (!folder) {
+			folder = (await promptForWorkspaceFolder()).folder;
+		}
 		const platform = node?.platform as Platform || (await selectPlatform()).id as Platform;
 
 		const taskDefinition: BuildTask = {
@@ -17,7 +21,7 @@ export async function buildModule (node?: DeviceNode | OSVerNode | PlatformNode 
 				titaniumBuild: {
 					projectType: 'module',
 					platform,
-					projectDir: vscode.workspace.rootPath!
+					projectDir: folder.uri.fsPath
 				},
 				type: 'titanium-build',
 				name: `Build ${platform}`

--- a/src/commands/packageModule.ts
+++ b/src/commands/packageModule.ts
@@ -2,15 +2,18 @@ import * as vscode from 'vscode';
 import { DeviceNode, OSVerNode, PlatformNode, TargetNode } from '../explorer/nodes';
 import { checkLogin, handleInteractionError, InteractionError } from './common';
 
-import { selectPlatform } from '../quickpicks/common';
+import { promptForWorkspaceFolder, selectPlatform } from '../quickpicks/common';
 import { getPackageTask } from '../tasks/tasksHelper';
 import { PackageTask } from '../tasks/packageTaskProvider';
 import { Platform } from '../types/common';
 
-export async function packageModule (node: DeviceNode | OSVerNode | PlatformNode | TargetNode): Promise<void> {
+export async function packageModule (node: DeviceNode | OSVerNode | PlatformNode | TargetNode, folder?: vscode.WorkspaceFolder): Promise<void> {
 	try {
 		checkLogin();
 
+		if (!folder) {
+			folder = (await promptForWorkspaceFolder()).folder;
+		}
 		const platform = node?.platform as Platform || (await selectPlatform()).id as Platform;
 
 		const taskDefinition: PackageTask = {
@@ -18,7 +21,7 @@ export async function packageModule (node: DeviceNode | OSVerNode | PlatformNode
 				titaniumBuild: {
 					projectType: 'module',
 					platform,
-					projectDir: vscode.workspace.rootPath!
+					projectDir: folder.uri.fsPath
 				},
 				type: 'titanium-package',
 				name: `Package ${platform}`

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -12,16 +12,16 @@ export class Configuration {
 	public get<T> (section?: string, resource?: Uri, defaultValue?: T): T {
 		return defaultValue === undefined
 			? workspace
-				.getConfiguration(section === undefined ? undefined : ExtensionName, resource!)
+				.getConfiguration(section === undefined ? undefined : ExtensionName, resource)
 				.get<T>(section === undefined ? ExtensionName : section)!
 			: workspace
-				.getConfiguration(section === undefined ? undefined : ExtensionName, resource!)
+				.getConfiguration(section === undefined ? undefined : ExtensionName, resource)
 				.get<T>(section === undefined ? ExtensionName : section, defaultValue)!;
 	}
 
 	public update (section: string, value: unknown, target: ConfigurationTarget, resource?: Uri): Thenable<void> {
 		return workspace
-			.getConfiguration(ExtensionName, target === ConfigurationTarget.Global ? undefined : resource!)
+			.getConfiguration(ExtensionName, target === ConfigurationTarget.Global ? undefined : resource)
 			.update(section, value, target);
 	}
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -8,7 +8,7 @@ import { HelpExplorer } from './explorer/helpExplorer';
 import DeviceExplorer from './explorer/tiExplorer';
 import { startup } from './extension';
 import { AppBuildTaskTitaniumBuildBase } from './tasks/buildTaskProvider';
-import { isDistributionAppBuild } from './tasks/tasksHelper';
+import { isDistributionAppBuild, RunningTask } from './tasks/tasksHelper';
 import { AppPackageTaskTitaniumBuildBase } from './tasks/packageTaskProvider';
 import { Project } from './project';
 import { generateCompletions } from './providers';
@@ -24,6 +24,7 @@ export class ExtensionContainer {
 	private static _helpExplorer: HelpExplorer;
 	private static _projects: Map<string, Project> = new Map();
 	private static _runningTask: vscode.TaskExecution|undefined;
+	private static _runningTasks: Map<string, RunningTask> = new Map();
 	private static _terminal: Terminal;
 	private static _updateInfo: UpdateInfo[];
 	private static _recentBuilds: Map<string, AppBuildTaskTitaniumBuildBase|AppPackageTaskTitaniumBuildBase>;
@@ -99,6 +100,10 @@ export class ExtensionContainer {
 
 	static get projects (): Map<string, Project> {
 		return this._projects;
+	}
+
+	static get runningTasks (): Map<string, RunningTask> {
+		return this._runningTasks;
 	}
 
 	/**

--- a/src/container.ts
+++ b/src/container.ts
@@ -33,6 +33,7 @@ export class ExtensionContainer {
 		this._appc = appc;
 		this._config = config;
 		this._context = context;
+		this._recentBuilds = new Map(context.workspaceState.get(WorkspaceState.RecentBuilds) || []);
 	}
 
 	static get appc (): Appc {

--- a/src/debugger/titaniumDebugConfigurationProvider.ts
+++ b/src/debugger/titaniumDebugConfigurationProvider.ts
@@ -22,10 +22,6 @@ function validateTask (task: AppBuildTaskDefinitionBase, ourConfig: vscode.Debug
 export class TitaniumDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 
 	public async resolveDebugConfiguration (folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration): Promise<vscode.DebugConfiguration> {
-		if (!config.projectDir) {
-			config.projectDir = '${workspaceFolder}'; // eslint-disable-line no-template-curly-in-string
-		}
-
 		const ourConfig: vscode.DebugConfiguration = {
 			...config
 		};
@@ -66,6 +62,10 @@ export class TitaniumDebugConfigurationProvider implements vscode.DebugConfigura
 				ourConfig.port = preLaunchTask.titaniumBuild.debugPort;
 				ourConfig.debugPort = preLaunchTask.titaniumBuild.debugPort;
 			}
+		}
+
+		if (!ourConfig.projectDir) {
+			ourConfig.projectDir = folder?.uri.fsPath || (await promptForWorkspaceFolder()).folder.uri.fsPath;
 		}
 
 		if (!ourConfig.platform) {

--- a/src/debugger/titaniumDebugConfigurationProvider.ts
+++ b/src/debugger/titaniumDebugConfigurationProvider.ts
@@ -2,7 +2,7 @@ import * as getPort from 'get-port';
 import * as vscode from 'vscode';
 import * as which from 'which';
 import { UserCancellation } from '../commands';
-import { selectPlatform } from '../quickpicks/common';
+import { promptForWorkspaceFolder, selectPlatform } from '../quickpicks/common';
 import { AppBuildTaskDefinitionBase } from '../tasks/buildTaskProvider';
 import { getTasks } from '../tasks/tasksHelper';
 
@@ -48,7 +48,8 @@ export class TitaniumDebugConfigurationProvider implements vscode.DebugConfigura
 		}
 
 		if (config.preLaunchTask) {
-			const preLaunchTask = getTasks<AppBuildTaskDefinitionBase>(vscode.workspace.rootPath!).find(task => task.label === config.preLaunchTask);
+			const { folder } = await promptForWorkspaceFolder();
+			const preLaunchTask = getTasks<AppBuildTaskDefinitionBase>(folder).find(task => task.label === config.preLaunchTask);
 
 			if (!preLaunchTask) {
 				throw new Error(`Unable to find a preLaunchTask named ${config.preLaunchTask}`);

--- a/src/debugger/titaniumDebugHelper.ts
+++ b/src/debugger/titaniumDebugHelper.ts
@@ -4,7 +4,6 @@ import { MESSAGE_STRING, Request, TitaniumLaunchRequestArgs, FeedbackOptions, Re
 import { BuildAppOptions } from '../types/cli';
 import { ExtensionContainer } from '../container';
 import appc from '../appc';
-import {  runningTasks } from '../tasks/tasksHelper';
 import { Commands } from '../commands';
 
 async function handleCustomEvent(event: vscode.DebugSessionCustomEvent): Promise<void> {
@@ -25,7 +24,7 @@ async function handleCustomEvent(event: vscode.DebugSessionCustomEvent): Promise
 			// on the label, so we need remove that to lookup the task
 			const taskLabel = providedArgs.preLaunchTask.replace('Titanium:', '').trim();
 
-			const runningTask = runningTasks.get(taskLabel);
+			const runningTask = ExtensionContainer.runningTasks.get(taskLabel);
 
 			if (!runningTask) {
 				response.result.isError = true;

--- a/src/debugger/titaniumPathTransformer.ts
+++ b/src/debugger/titaniumPathTransformer.ts
@@ -70,8 +70,9 @@ export class TitaniumPathTransformer extends BasePathTransformer {
 	}
 
 	public getTargetPathFromClientPath (clientPath: string): string {
-		if (path.isAbsolute(clientPath) && this._localPathToTargetUrl.has(utils.canonicalizeUrl(clientPath))) {
-			clientPath = this._localPathToTargetUrl.get(utils.canonicalizeUrl(clientPath))!;
+		const targetUrl = this._localPathToTargetUrl.get(utils.canonicalizeUrl(clientPath));
+		if (path.isAbsolute(clientPath) && targetUrl) {
+			clientPath = targetUrl;
 		}
 		return clientPath;
 	}

--- a/src/providers/completion/baseCompletionItemProvider.ts
+++ b/src/providers/completion/baseCompletionItemProvider.ts
@@ -1,20 +1,37 @@
 import { completion } from 'titanium-editor-commons';
-import project from '../../project';
+import { Project } from '../../project';
 import * as vscode from 'vscode';
+import { ExtensionContainer } from '../../container';
+import * as utils from '../../utils';
 
 export const CompletionsFormat = completion.CompletionsFormat.v3;
 
 export abstract class BaseCompletionItemProvider implements vscode.CompletionItemProvider {
 	public CompletionsFormat = CompletionsFormat;
 	public completions: any
+	public completionsMap = new Map<string, any>();
 
 	public abstract provideCompletionItems (document: vscode.TextDocument, position: vscode.Position): Promise<vscode.CompletionItem[]>
 
-	public async loadCompletions (): Promise<void> {
-		const sdk = project.sdk()[0];
-
+	public async loadCompletions (sdk: string): Promise<void> {
 		if (!this.completions) {
 			this.completions = await completion.loadCompletions(sdk, this.CompletionsFormat);
+			this.completionsMap.set(sdk, this.completions);
 		}
+	}
+
+	public async getCompletions (proj: Project): Promise<any> {
+		const sdk = proj.sdk()[0];
+		if (!this.completionsMap.has(sdk)) {
+			await this.loadCompletions(sdk);
+		}
+
+		return this.completionsMap.get(sdk);
+	}
+
+	public async getProject (document: vscode.TextDocument): Promise< Project|undefined> {
+		const filePath = document.uri.fsPath;
+		const projectDir = await utils.findProjectDirectory(filePath);
+		return ExtensionContainer.projects.get(projectDir);
 	}
 }

--- a/src/providers/completion/controllerCompletionItemProvider.ts
+++ b/src/providers/completion/controllerCompletionItemProvider.ts
@@ -136,6 +136,7 @@ export class ControllerCompletionItemProvider extends BaseCompletionItemProvider
 		}
 		const document = await workspace.openTextDocument(relatedFile);
 		let tagName;
+		// eslint-disable-next-line security/detect-non-literal-regexp
 		const regex = new RegExp(`id=["']${id}["']`, 'g');
 		const ids = regex.exec(document.getText());
 		if (ids) {
@@ -332,6 +333,7 @@ export class ControllerCompletionItemProvider extends BaseCompletionItemProvider
 		}
 		const document = await workspace.openTextDocument(relatedFile);
 		let tagName;
+		// eslint-disable-next-line security/detect-non-literal-regexp
 		const regex = new RegExp(`id=["']${id}["']`, 'g');
 		const ids = regex.exec(document.getText());
 		if (ids) {

--- a/src/providers/completion/tiappCompletionItemProvider.ts
+++ b/src/providers/completion/tiappCompletionItemProvider.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import appc from '../../appc';
 import * as utils from '../../utils';
 
-import { CompletionItem, CompletionItemKind, Position, Range, TextDocument, workspace } from 'vscode';
+import { CompletionItem, CompletionItemKind, Position, Range, TextDocument } from 'vscode';
 import { BaseCompletionItemProvider } from './baseCompletionItemProvider';
 /**
  * Tiapp.xml completion provider
@@ -22,6 +22,12 @@ export class TiappCompletionItemProvider extends BaseCompletionItemProvider {
 	 * @returns {Thenable|Array}
 	 */
 	public async provideCompletionItems (document: TextDocument, position: Position): Promise<CompletionItem[]> {
+		const project = await this.getProject(document);
+
+		if (!project) {
+			return [];
+		}
+
 		const linePrefix = document.getText(new Range(position.line, 0, position.line, position.character));
 		const completions: CompletionItem[] = [];
 		let tag;
@@ -54,13 +60,13 @@ export class TiappCompletionItemProvider extends BaseCompletionItemProvider {
 			 * - Add support for adding to the platform property
 			 * - Add support for the deploy type tag
 			 */
-			const modulePath = path.join(workspace.rootPath!, 'modules');
+			const modulePath = path.join(project.filePath, 'modules');
 			if (!utils.directoryExists(modulePath)) {
 				return completions;
 			}
 			const modules: { [key: string]: { platforms: string[] } } = {};
 			for (const platform of this.getDirectories(modulePath)) {
-				const platformModulePath = path.join(workspace.rootPath!, 'modules', platform);
+				const platformModulePath = path.join(project.filePath, 'modules', platform);
 				for (const moduleName of this.getDirectories(platformModulePath)) {
 					if (!modules[moduleName]) {
 						modules[moduleName] = {

--- a/src/providers/completion/tiappCompletionItemProvider.ts
+++ b/src/providers/completion/tiappCompletionItemProvider.ts
@@ -48,7 +48,7 @@ export class TiappCompletionItemProvider extends BaseCompletionItemProvider {
 					continue;
 				}
 				completions.push({
-					label: sdk.fullversion!,
+					label: sdk.fullversion || sdk.version,
 					kind: CompletionItemKind.Value,
 					insertText: sdk.fullversion?.replace(sdkVersion, '')
 				});

--- a/src/providers/completion/viewCompletionItemProvider.ts
+++ b/src/providers/completion/viewCompletionItemProvider.ts
@@ -78,7 +78,9 @@ export class ViewCompletionItemProvider extends BaseCompletionItemProvider {
 		const { alloy } = await this.getCompletions(project);
 		const { tags } = alloy;
 		const completions: CompletionItem[] = [];
+		// eslint-disable-next-line security/detect-non-literal-regexp
 		const isClosing = new RegExp(`</${prefix || ''}$`).test(linePrefix);
+		// eslint-disable-next-line security/detect-non-literal-regexp
 		const useSnippet = new RegExp(`^\\s*</?${prefix || ''}\\s*>?\\s*$`).test(line);
 		const range = prefixRange ? new Range(position.line, prefixRange.start.character, position.line, line.length) : new Range(position.line, position.character, position.line, line.length);
 		for (const tag in tags) {

--- a/src/providers/definition/common.ts
+++ b/src/providers/definition/common.ts
@@ -34,6 +34,7 @@ export const viewSuggestions: DefinitionSuggestion[] = [
 			return getRelatedFiles(project, 'tss');
 		},
 		definitionRegExp (text: string): RegExp {
+			// eslint-disable-next-line security/detect-non-literal-regexp
 			return new RegExp(`["']\\.${text}["'[]`, 'g');
 		},
 		title (fileName: string): string {
@@ -51,6 +52,7 @@ export const viewSuggestions: DefinitionSuggestion[] = [
 			return getRelatedFiles(project, 'tss');
 		},
 		definitionRegExp (text: string): RegExp {
+			// eslint-disable-next-line security/detect-non-literal-regexp
 			return new RegExp(`["']#${text}["'[]`, 'g');
 		},
 		title (fileName: string): string {
@@ -68,6 +70,7 @@ export const viewSuggestions: DefinitionSuggestion[] = [
 			return getRelatedFiles(project, 'tss');
 		},
 		definitionRegExp (text: string): RegExp {
+			// eslint-disable-next-line security/detect-non-literal-regexp
 			return new RegExp(`["']${text}`, 'g');
 		},
 		title (fileName: string): string {
@@ -89,6 +92,7 @@ export const viewSuggestions: DefinitionSuggestion[] = [
 			return getRelatedFiles(project, 'js');
 		},
 		definitionRegExp (text: string): RegExp {
+			// eslint-disable-next-line security/detect-non-literal-regexp
 			return new RegExp(`function ${text}\\s*?\\(`);
 		},
 		title (fileName: string): string {
@@ -115,6 +119,7 @@ export const viewSuggestions: DefinitionSuggestion[] = [
 	{ // i18n
 		regExp: /[:\s=,>)("]L\(["'][\w0-9_-]*$/,
 		definitionRegExp(text: string): RegExp {
+			// eslint-disable-next-line security/detect-non-literal-regexp
 			return new RegExp(`name=["']${text}["']>(.*)?</`, 'g');
 		},
 		async files(project: Project): Promise<string[]> {

--- a/src/providers/definition/controllerDefinitionProvider.ts
+++ b/src/providers/definition/controllerDefinitionProvider.ts
@@ -1,62 +1,62 @@
 import * as path from 'path';
-import * as utils from '../../utils';
 import { provideDefinition } from './definitionProviderHelper';
 
 import * as vscode from 'vscode';
 import { DefinitionSuggestion } from './common';
+import { Project } from '../../project';
 
 interface ControllerSuggestion extends DefinitionSuggestion {
-	files (document: vscode.TextDocument, text: string, value: string): string[];
+	files (project: Project, document: vscode.TextDocument, text: string, value: string): string[];
 }
 
 const suggestions: ControllerSuggestion[] = [
 	{ // require (/lib) name
 		regExp: /require\(["']([-a-zA-Z0-9-_/]*)$/,
-		files (document: vscode.TextDocument, text: string, value: string): string[] {
-			return [ path.join(utils.getAlloyRootPath(), 'lib', `${value}.js`) ];
+		files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {
+			return [ path.join(project.filePath, 'app', 'lib', `${value}.js`) ];
 		}
 	},
 	{ // controller name
 		regExp: /Alloy\.createController\(["']([-a-zA-Z0-9-_/]*)$/,
-		files (document: vscode.TextDocument, text: string, value: string): string[] {
-			return [ path.join(utils.getAlloyRootPath(), 'controllers', `${value}.js`) ];
+		files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {
+			return [ path.join(project.filePath, 'app', 'controllers', `${value}.js`) ];
 		}
 	},
 	{ // collection / model name (instance)
 		regExp: /Alloy\.(Collections|Models).instance\(["']([-a-zA-Z0-9-_/]*)$/,
-		files (document: vscode.TextDocument, text: string, value: string): string[] {
-			return [ path.join(utils.getAlloyRootPath(), 'models', `${value}.js`) ];
+		files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {
+			return [ path.join(project.filePath, 'app', 'models', `${value}.js`) ];
 		}
 	},
 	{ // collection / model name (create)
 		regExp: /Alloy\.create(Collection|Model)\(["']([-a-zA-Z0-9-_/]*)$/,
-		files (document: vscode.TextDocument, text: string, value: string): string[] {
-			return [ path.join(utils.getAlloyRootPath(), 'models', `${value}.js`) ];
+		files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {
+			return [ path.join(project.filePath, 'app', 'models', `${value}.js`) ];
 		}
 	},
 	{ // widget name
 		regExp: /Alloy\.createWidget\(["']([-a-zA-Z0-9-_/.]*)$/,
-		files (document: vscode.TextDocument, text: string, value: string): string[] {
-			return [ path.join(utils.getAlloyRootPath(), 'widgets', value, 'controllers', 'widget.js') ];
+		files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {
+			return [ path.join(project.filePath, 'app', 'widgets', value, 'controllers', 'widget.js') ];
 		}
 	},
 	{ // controller name
 		regExp: /Widget\.createController\(["']([-a-zA-Z0-9-_/]*)$/,
-		files (document: vscode.TextDocument, text: string, value: string): string[] {
+		files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {
 			const dir = path.dirname(document.fileName);
 			return [ path.join(dir, `${value}.js`) ];
 		}
 	},
 	{ // collection / model name (instance)
 		regExp: /Widget\.(Collections|Models).instance\(["']([-a-zA-Z0-9-_/]*)$/,
-		files (document: vscode.TextDocument, text: string, value: string): string[] {
+		files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {
 			const dir = path.dirname(document.fileName);
 			return [ path.resolve(dir, `../models/${value}.js`) ];
 		}
 	},
 	{ // collection / model name (create)
 		regExp: /Widget\.create(Collection|Model)\(["']([-a-zA-Z0-9-_/]*)$/,
-		files (document: vscode.TextDocument, text: string, value: string): string[] {
+		files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {
 			const dir = path.dirname(document.fileName);
 			return [ path.resolve(dir, `../models/${value}.js`) ];
 		}

--- a/src/providers/definition/definitionProviderHelper.ts
+++ b/src/providers/definition/definitionProviderHelper.ts
@@ -61,6 +61,7 @@ export async function provideHover (document: TextDocument, position: Position):
 	if (/image\s*[=:]\s*["'][\s0-9a-zA-Z-_^./]*$/.test(linePrefix)) {
 		const relativePath = path.parse(value);
 		const dir = path.join(project?.filePath, 'app', 'assets');
+		// eslint-disable-next-line security/detect-non-literal-regexp
 		const fileNameRegExp = new RegExp(`${relativePath.name}.*${relativePath.ext}$`);
 		const files = walkSync(dir, {
 			nodir: true,

--- a/src/providers/definition/styleDefinitionProvider.ts
+++ b/src/providers/definition/styleDefinitionProvider.ts
@@ -1,3 +1,4 @@
+import { Project } from '../../project';
 import * as vscode from 'vscode';
 import * as related from '../../related';
 import { DefinitionSuggestion } from './common';
@@ -9,8 +10,8 @@ const suggestions: DefinitionSuggestion[] = [
 		definitionRegExp (text: string): RegExp {
 			return new RegExp(`id=["']${text.replace('#', '')}`, 'g');
 		},
-		files (document: vscode.TextDocument): string[] {
-			const relatedFile = related.getTargetPath('xml', document.fileName);
+		files (project: Project, document: vscode.TextDocument): string[] {
+			const relatedFile = related.getTargetPath(project, 'xml', document.fileName);
 			if (relatedFile) {
 				return [ relatedFile ];
 			}
@@ -22,8 +23,8 @@ const suggestions: DefinitionSuggestion[] = [
 		definitionRegExp (text: string): RegExp {
 			return new RegExp(`class=["']${text.replace('.', '')}`, 'g');
 		},
-		files (document: vscode.TextDocument): string[] {
-			const relatedFile = related.getTargetPath('xml', document.fileName);
+		files (project: Project, document: vscode.TextDocument): string[] {
+			const relatedFile = related.getTargetPath(project, 'xml', document.fileName);
 			if (relatedFile) {
 				return [ relatedFile ];
 			}

--- a/src/providers/definition/styleDefinitionProvider.ts
+++ b/src/providers/definition/styleDefinitionProvider.ts
@@ -8,6 +8,7 @@ const suggestions: DefinitionSuggestion[] = [
 	{ // id
 		regExp: /["']#[A-Za-z0-9_=[\]]+/,
 		definitionRegExp (text: string): RegExp {
+			// eslint-disable-next-line security/detect-non-literal-regexp
 			return new RegExp(`id=["']${text.replace('#', '')}`, 'g');
 		},
 		files (project: Project, document: vscode.TextDocument): string[] {
@@ -21,6 +22,7 @@ const suggestions: DefinitionSuggestion[] = [
 	{ // class
 		regExp: /["']\.[A-Za-z0-9_=[\]]+/,
 		definitionRegExp (text: string): RegExp {
+			// eslint-disable-next-line security/detect-non-literal-regexp
 			return new RegExp(`class=["']${text.replace('.', '')}`, 'g');
 		},
 		files (project: Project, document: vscode.TextDocument): string[] {

--- a/src/providers/definition/viewHoverProvider.ts
+++ b/src/providers/definition/viewHoverProvider.ts
@@ -4,7 +4,7 @@ import { HoverProvider, Position, TextDocument, Hover } from 'vscode';
 
 export class ViewHoverProvider implements HoverProvider {
 
-	public provideHover (document: TextDocument, position: Position): Hover|undefined {
+	public async provideHover (document: TextDocument, position: Position): Promise<Hover|undefined> {
 		return definitionProviderHelper.provideHover(document, position);
 	}
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,6 @@
 import { handleInteractionError, InteractionChoice, InteractionError, registerCommand } from '../commands';
 import * as vscode from 'vscode';
-import project from '../project';
+import { Project } from '../project';
 import { completion, updates } from 'titanium-editor-commons';
 import appc from '../appc';
 import * as path from 'path';
@@ -58,8 +58,9 @@ export function registerProviders(context: vscode.ExtensionContext): void {
 * Generate Alloy and Titanium SDK Completion files
 *
 * @param {boolean} [force=false] generate the completions even if they exist
+* @param {Project} project - The Titanium project instance
 */
-export async function generateCompletions (force = false): Promise<void> {
+export async function generateCompletions (force = false, project: Project): Promise<void> {
 	if (!project.isValid()) {
 		return;
 	}
@@ -71,7 +72,7 @@ export async function generateCompletions (force = false): Promise<void> {
 			error.interactionChoices.push({
 				title: 'Open tiapp.xml',
 				run: async () => {
-					const file = path.join(vscode.workspace.rootPath!, 'tiapp.xml');
+					const file = path.join(project.filePath, 'tiapp.xml');
 					const document = await vscode.workspace.openTextDocument(file);
 					await vscode.window.showTextDocument(document);
 				}
@@ -82,7 +83,7 @@ export async function generateCompletions (force = false): Promise<void> {
 			error.interactionChoices.push({
 				title: 'Open tiapp.xml',
 				run: async () => {
-					const file = path.join(vscode.workspace.rootPath!, 'tiapp.xml');
+					const file = path.join(project.filePath, 'tiapp.xml');
 					const document = await vscode.workspace.openTextDocument(file);
 					await vscode.window.showTextDocument(document);
 				}
@@ -130,7 +131,7 @@ export async function generateCompletions (force = false): Promise<void> {
 						try {
 							await updates.titanium.sdk.installUpdate(sdkVersion as string);
 							await appc.getInfo();
-							await generateCompletions(force);
+							await generateCompletions(force, project);
 						} catch (err) {
 							return Promise.reject(err);
 						}

--- a/src/quickpicks/build/android.ts
+++ b/src/quickpicks/build/android.ts
@@ -37,7 +37,7 @@ export function selectAndroidEmulator (): Promise<DeviceQuickPickItem>  {
 	return deviceQuickPick(options, { placeHolder: 'Select emulator' });
 }
 
-export async function selectAndroidKeystore (lastUsed?: string, savedKeystorePath?: string): Promise<string|undefined> {
+export async function selectAndroidKeystore (workspaceFolder: vscode.WorkspaceFolder, lastUsed?: string, savedKeystorePath?: string): Promise<string|undefined> {
 	const items = [ {
 		label: 'Browse for keystore',
 		id: 'browse'
@@ -63,7 +63,7 @@ export async function selectAndroidKeystore (lastUsed?: string, savedKeystorePat
 		return uri[0].path;
 	} else if (savedKeystorePath && keystoreAction.id === 'saved') {
 		if (!path.isAbsolute(savedKeystorePath)) {
-			savedKeystorePath = path.resolve(vscode.workspace.rootPath!, savedKeystorePath);
+			savedKeystorePath = path.resolve(workspaceFolder.uri.fsPath, savedKeystorePath);
 		}
 		return savedKeystorePath;
 	} else if (lastUsed) {
@@ -101,7 +101,7 @@ export async function enterAndroidKeystoreInfo (workspaceFolder: vscode.Workspac
 	const savedKeystorePath = ExtensionContainer.config.android.keystorePath;
 
 	if (!keystoreInfo?.location) {
-		keystoreInfo.location = await selectAndroidKeystore(lastUsed, savedKeystorePath);
+		keystoreInfo.location = await selectAndroidKeystore(workspaceFolder, lastUsed, savedKeystorePath);
 	}
 
 	await verifyKeystorePath(keystoreInfo.location, workspaceFolder);

--- a/src/quickpicks/common.ts
+++ b/src/quickpicks/common.ts
@@ -171,7 +171,7 @@ export async function getValidWorkspaceFolders({ apps = true, modules = false } 
 	const { workspaceFolders } = workspace;
 
 	if (!workspaceFolders) {
-		throw new Error('No workspace folders');
+		return [];
 	}
 
 	const folders = [];
@@ -221,6 +221,9 @@ interface FolderDetails {
  */
 export async function promptForWorkspaceFolder ({ apps = true, modules = false, placeHolder = 'Please select a folder to perform action within' }: WorkspaceFolderPromptOptions = {}): Promise<FolderDetails> {
 	const folders = await getValidWorkspaceFolders({ apps, modules });
+	if (!folders.length) {
+		throw new Error('No workspace folders are present');
+	}
 	const choices: CustomQuickPick[] = folders.map(({ folder }) => ({ label: folder.name, id: folder.uri.fsPath  }));
 
 	const choice = await quickPick(choices, { canPickMany: false, placeHolder });

--- a/src/quickpicks/common.ts
+++ b/src/quickpicks/common.ts
@@ -227,13 +227,11 @@ export async function promptForWorkspaceFolder ({ apps = true, modules = false, 
 	const choices: CustomQuickPick[] = folders.map(({ folder }) => ({ label: folder.name, id: folder.uri.fsPath  }));
 
 	const choice = await quickPick(choices, { canPickMany: false, placeHolder });
-	if (!choice) {
-		throw new Error('no choice');
-	}
+
 	const folder = folders.find(({ folder }) => folder.uri.fsPath === choice.id);
 	if (!folder) {
 		// should not happen unless removed between prompt and pick?
-		throw new Error('could not find');
+		throw new Error(`Could not find ${choice.id}. Has it been removed?`);
 	}
 	return folder;
 }

--- a/src/tasks/commandTaskProvider.ts
+++ b/src/tasks/commandTaskProvider.ts
@@ -43,7 +43,7 @@ export abstract class CommandTaskProvider implements vscode.TaskProvider {
 
 	protected constructor (private readonly telemetryName: string, private readonly helpers: Helpers) { }
 
-	public provideTasks (): vscode.Task[] {
+	public async provideTasks (): Promise<vscode.Task[]> {
 		return [];
 	}
 

--- a/src/tasks/helpers/android.ts
+++ b/src/tasks/helpers/android.ts
@@ -1,4 +1,4 @@
-import { TaskExecutionContext, runningTasks } from '../tasksHelper';
+import { TaskExecutionContext } from '../tasksHelper';
 import { TaskHelper } from './base';
 import { Command } from '../commandBuilder';
 import { enterAndroidKeystoreInfo } from '../../quickpicks/build/android';
@@ -6,6 +6,7 @@ import { KeystoreInfo } from '../../types/common';
 import { AppBuildTaskTitaniumBuildBase, BuildTaskDefinitionBase, BuildTaskTitaniumBuildBase } from '../buildTaskProvider';
 import { AppPackageTaskTitaniumBuildBase, PackageTaskDefinitionBase, PackageTaskTitaniumBuildBase } from '../packageTaskProvider';
 import { WorkspaceState } from '../../constants';
+import { ExtensionContainer } from '../../container';
 
 export interface AndroidBuildTaskDefinition extends BuildTaskDefinitionBase {
 	titaniumBuild: AndroidBuildTaskTitaniumBuildBase;
@@ -39,7 +40,7 @@ export class AndroidHelper extends TaskHelper {
 		}
 
 		this.storeLastState(WorkspaceState.LastBuildState, definition);
-		runningTasks.set(context.label, { buildOptions: definition });
+		ExtensionContainer.runningTasks.set(context.label, { buildOptions: definition });
 
 		return builder.resolve();
 	}

--- a/src/tasks/helpers/base.ts
+++ b/src/tasks/helpers/base.ts
@@ -9,10 +9,10 @@ import { UserCancellation } from '../../commands/common';
 import { BuildTaskTitaniumBuildBase, AppBuildTaskTitaniumBuildBase } from '../buildTaskProvider';
 import { PackageTaskTitaniumBuildBase, AppPackageTaskTitaniumBuildBase } from '../packageTaskProvider';
 import { TitaniumBuildBase } from '../commandTaskProvider';
-import project from '../../project';
 import { WorkspaceState } from '../../constants';
 import { selectDevice } from '../../quickpicks/build/common';
 import { IosBuildTaskTitaniumBuildBase } from './ios';
+import { Project } from '../../project';
 
 function isAppBuild<T extends TitaniumBuildBase>(definition: TitaniumBuildBase): definition is T {
 	if (definition.projectType === 'app') {
@@ -89,6 +89,7 @@ export abstract class TaskHelper {
 			builder.addOption('--device-id', definition.deviceId);
 		}
 
+		const project = this.getProject(definition.projectDir);
 		builder.addQuotedOption('--sdk', project.sdk()[0]);
 
 	}
@@ -163,5 +164,13 @@ export abstract class TaskHelper {
 		} else {
 			return CommandBuilder.create('appc', 'run');
 		}
+	}
+
+	public getProject(projectDir: string): Project {
+		const project = ExtensionContainer.projects.get(projectDir);
+		if (!project) {
+			throw new Error(`Unable to find loaded project for ${projectDir}, please ensure it is active in the workspace`);
+		}
+		return project;
 	}
 }

--- a/src/tasks/helpers/ios.ts
+++ b/src/tasks/helpers/ios.ts
@@ -1,4 +1,4 @@
-import { TaskExecutionContext, runningTasks } from '../tasksHelper';
+import { TaskExecutionContext } from '../tasksHelper';
 import { selectiOSCertificate, selectiOSProvisioningProfile } from '../../quickpicks/build/ios';
 import { getCorrectCertificateName } from '../../utils';
 import { IosCertificateType, IosCert } from '../../types/common';
@@ -9,6 +9,7 @@ import { AppPackageTaskTitaniumBuildBase, PackageTaskDefinitionBase, PackageTask
 import { WorkspaceState } from '../../constants';
 
 import appc from '../../appc';
+import { ExtensionContainer } from '../../container';
 
 export interface IosTitaniumBuildDefinition extends BuildTaskDefinitionBase {
 	titaniumBuild: IosBuildTaskTitaniumBuildBase;
@@ -76,7 +77,7 @@ export class IosHelper extends TaskHelper {
 		}
 
 		this.storeLastState(WorkspaceState.LastBuildState, definition);
-		runningTasks.set(context.label, { buildOptions: definition });
+		ExtensionContainer.runningTasks.set(context.label, { buildOptions: definition });
 
 		return builder.resolve();
 	}

--- a/src/tasks/helpers/ios.ts
+++ b/src/tasks/helpers/ios.ts
@@ -1,7 +1,6 @@
 import { TaskExecutionContext, runningTasks } from '../tasksHelper';
 import { selectiOSCertificate, selectiOSProvisioningProfile } from '../../quickpicks/build/ios';
 import { getCorrectCertificateName } from '../../utils';
-import project from '../../project';
 import { IosCertificateType, IosCert } from '../../types/common';
 import { TaskHelper } from './base';
 import { Command } from '../commandBuilder';
@@ -41,6 +40,7 @@ export class IosHelper extends TaskHelper {
 
 	public async resolveAppBuildCommandLine (context: TaskExecutionContext, definition: IosBuildTaskTitaniumBuildBase): Promise<Command> {
 		const builder = this.createBuilder();
+		const project = this.getProject(definition.projectDir);
 
 		await this.resolveCommonAppOptions(context, definition, builder);
 
@@ -84,6 +84,7 @@ export class IosHelper extends TaskHelper {
 
 	public async resolveAppPackageCommandLine(context: TaskExecutionContext, definition: IosPackageTaskTitaniumBuildBase): Promise<Command> {
 		const builder = this.createBuilder();
+		const project = this.getProject(definition.projectDir);
 
 		await this.resolveCommonPackagingOptions(context, definition, builder);
 

--- a/src/tasks/helpers/ios.ts
+++ b/src/tasks/helpers/ios.ts
@@ -49,8 +49,7 @@ export class IosHelper extends TaskHelper {
 			let certificate: IosCert|undefined;
 
 			if (!iosInfo.certificate) {
-				iosInfo.certificate = (await selectiOSCertificate('run')).id;
-				certificate = appc.iOSCertificates().find(cert => cert.fullname === iosInfo.certificate);
+				certificate = await selectiOSCertificate('run');
 			} else {
 				certificate = appc.iOSCertificates().find(cert => cert.fullname === iosInfo.certificate);
 			}
@@ -62,7 +61,7 @@ export class IosHelper extends TaskHelper {
 			iosInfo.certificate =  getCorrectCertificateName(certificate.fullname, project.sdk()[0], IosCertificateType.developer);
 
 			if (!iosInfo.provisioningProfile) {
-				iosInfo.provisioningProfile = (await selectiOSProvisioningProfile(certificate, 'run', project.appId())).uuid;
+				iosInfo.provisioningProfile = (await selectiOSProvisioningProfile(certificate, definition.target, project.appId())).uuid;
 			}
 
 			if (!iosInfo.provisioningProfile) {
@@ -92,8 +91,7 @@ export class IosHelper extends TaskHelper {
 		let certificate: IosCert|undefined;
 
 		if (!iosInfo.certificate) {
-			iosInfo.certificate = (await selectiOSCertificate('distribute')).id;
-			certificate = appc.iOSCertificates(IosCertificateType.distribution).find(cert => cert.fullname === iosInfo.certificate);
+			certificate = await selectiOSCertificate('distribute');
 		} else {
 			certificate = appc.iOSCertificates(IosCertificateType.distribution).find(cert => cert.fullname === iosInfo.certificate);
 		}
@@ -105,7 +103,7 @@ export class IosHelper extends TaskHelper {
 		iosInfo.certificate =  getCorrectCertificateName(certificate.fullname, project.sdk()[0], IosCertificateType.distribution);
 
 		if (!iosInfo.provisioningProfile) {
-			iosInfo.provisioningProfile = (await selectiOSProvisioningProfile(certificate, definition.target, project.appId())).id;
+			iosInfo.provisioningProfile = (await selectiOSProvisioningProfile(certificate, definition.target, project.appId())).uuid;
 		}
 
 		if (!iosInfo.provisioningProfile) {

--- a/src/tasks/packageTaskProvider.ts
+++ b/src/tasks/packageTaskProvider.ts
@@ -1,4 +1,3 @@
-import * as vscode from 'vscode';
 import * as path from 'path';
 import { CommandTaskProvider, TitaniumTaskBase, TitaniumTaskDefinitionBase, TitaniumBuildBase } from './commandTaskProvider';
 import { Helpers } from './helpers';
@@ -6,6 +5,7 @@ import { TaskExecutionContext } from './tasksHelper';
 import { selectDistributionTarget } from '../quickpicks/build/common';
 import { DeploymentTarget } from '../types/cli';
 import { Command } from './commandBuilder';
+import { promptForWorkspaceFolder } from '../quickpicks';
 
 export interface PackageTask extends TitaniumTaskBase {
 	definition: PackageTaskDefinitionBase;
@@ -38,7 +38,15 @@ export class PackageTaskProvider extends CommandTaskProvider {
 		const { definition } = task;
 
 		if (!definition.titaniumBuild.projectDir) {
-			definition.titaniumBuild.projectDir = vscode.workspace.rootPath!;
+			const folderDetectOptions = { apps: true, modules: true };
+
+			if (definition.titaniumBuild.projectType === 'app') {
+				folderDetectOptions.modules = false;
+			} else if (definition.titaniumBuild.projectType === 'module') {
+				folderDetectOptions.apps = false;
+			}
+			const { folder } = await promptForWorkspaceFolder(folderDetectOptions);
+			definition.titaniumBuild.projectDir = folder.uri.fsPath;
 		}
 
 		const helper = this.getHelper(definition.titaniumBuild.platform);

--- a/src/tasks/taskPseudoTerminal.ts
+++ b/src/tasks/taskPseudoTerminal.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { CommandTaskProvider, TitaniumTaskBase, TitaniumTaskDefinitionBase } from './commandTaskProvider';
-import { TaskExecutionContext, runningTasks } from './tasksHelper';
+import { TaskExecutionContext } from './tasksHelper';
 import * as cp from 'child_process';
 import { ExtensionContainer } from '../container';
 import { GlobalState } from '../constants';
@@ -111,8 +111,8 @@ export class TaskPseudoTerminal implements vscode.Pseudoterminal {
 		this.closeEmitter.fire(code || 0);
 		ExtensionContainer.context.globalState.update(GlobalState.Running, false);
 		vscode.commands.executeCommand('setContext', GlobalState.Running, false);
-		if (runningTasks.has(this.task.name)) {
-			runningTasks.delete(this.task.name);
+		if (ExtensionContainer.runningTasks.has(this.task.name)) {
+			ExtensionContainer.runningTasks.delete(this.task.name);
 		}
 	}
 

--- a/src/tasks/tasksHelper.ts
+++ b/src/tasks/tasksHelper.ts
@@ -87,8 +87,8 @@ export async function getPackageTask(task: TitaniumTaskBase): Promise<vscode.Tas
  * @param {string} folder - Workspace folder to get tasks for.
  * @returns {TitaniumTaskDefinitionBase[]}
  */
-export function getTasks <T extends TitaniumTaskDefinitionBase> (folder: string): T[] {
-	const workspaceTasks = vscode.workspace.getConfiguration('tasks', vscode.Uri.file(folder));
+export function getTasks <T extends TitaniumTaskDefinitionBase> (folder: vscode.WorkspaceFolder): T[] {
+	const workspaceTasks = vscode.workspace.getConfiguration('tasks', folder);
 	const allTasks = workspaceTasks && workspaceTasks.tasks as T[] || [];
 
 	return allTasks;

--- a/src/tasks/tasksHelper.ts
+++ b/src/tasks/tasksHelper.ts
@@ -14,7 +14,6 @@ export interface RunningTask {
 	buildOptions: AppBuildTaskTitaniumBuildBase;
 }
 
-export const runningTasks: Map<string, RunningTask> = new Map();
 export const debugSessionInformation: Map<string, DeviceNode> = new Map();
 export const DEBUG_SESSION_VALUE = 'DEBUG_SESSION_VALUE';
 

--- a/src/test/unit/suite/appc.test.ts
+++ b/src/test/unit/suite/appc.test.ts
@@ -18,7 +18,7 @@ describe('SDKs', () => {
 		});
 
 		it('should retrieve the latest SDK', () => {
-			expect(Appc.latestSdk(false)!.fullversion).to.equal('7.0.0.v20170815160201');
+			expect(Appc.latestSdk(false)?.fullversion).to.equal('7.0.0.v20170815160201');
 		});
 	});
 
@@ -31,7 +31,7 @@ describe('SDKs', () => {
 		});
 
 		it('should retrieve the latest GA SDK', () => {
-			expect(Appc.latestSdk()!.fullversion).to.equal('6.1.2.GA');
+			expect(Appc.latestSdk()?.fullversion).to.equal('6.1.2.GA');
 		});
 	});
 

--- a/src/test/unit/suite/controllerAutoCompleteProvider.test.ts
+++ b/src/test/unit/suite/controllerAutoCompleteProvider.test.ts
@@ -3,9 +3,8 @@ import * as fs from 'fs';
 import { after, before, describe, it } from 'mocha';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import * as tce from 'titanium-editor-commons';
+import { Project } from '../../../project';
 import * as vscode from 'vscode';
-import project from '../../../project';
 
 import { ControllerCompletionItemProvider } from '../../../providers/completion/controllerCompletionItemProvider';
 
@@ -15,21 +14,20 @@ const uri = vscode.Uri.file(file);
 const rawData = fs.readFileSync(path.join(fixturesPath, 'data', 'completions.json'), 'utf8');
 const completions = JSON.parse(rawData);
 
-async function testCompletion (position: vscode.Position): Promise<vscode.CompletionItem[]> {
-	const text = await vscode.workspace.openTextDocument(uri);
-	const provider = new ControllerCompletionItemProvider();
-	return provider.provideCompletionItems(text, position);
-}
-
 let sandbox: sinon.SinonSandbox;
 
 describe('Controller suggestions', () => {
+	const provider = new ControllerCompletionItemProvider();
+	async function testCompletion (position: vscode.Position): Promise<vscode.CompletionItem[]> {
+		const text = await vscode.workspace.openTextDocument(uri);
+		return provider.provideCompletionItems(text, position);
+	}
 
 	before(async function () {
 		this.timeout(5000);
 		sandbox = sinon.createSandbox();
-		sandbox.stub(project, 'sdk').returns([ '8.1.0.GA' ]);
-		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
+		sandbox.stub(provider, 'getProject').resolves(new Project('/test', 'app'));
+		sandbox.stub(provider, 'getCompletions').resolves(completions);
 	});
 
 	after(async function () {

--- a/src/test/unit/suite/styleAutoCompleteProvider.test.ts
+++ b/src/test/unit/suite/styleAutoCompleteProvider.test.ts
@@ -4,9 +4,8 @@ import * as fs from 'fs';
 import { after, before, describe, it } from 'mocha';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import * as tce from 'titanium-editor-commons';
+import { Project } from '../../../project';
 import * as vscode from 'vscode';
-import project from '../../../project';
 
 import { StyleCompletionItemProvider } from '../../../providers/completion/styleCompletionItemProvider';
 
@@ -16,20 +15,19 @@ const uri = vscode.Uri.file(file);
 const rawData = fs.readFileSync(path.join(fixturesPath, 'data', 'completions.json'), 'utf8');
 const completions = JSON.parse(rawData);
 
-async function testCompletion (position: vscode.Position): Promise<vscode.CompletionItem[]> {
-	const text = await vscode.workspace.openTextDocument(uri);
-	const provider = new StyleCompletionItemProvider();
-	return provider.provideCompletionItems(text, position);
-}
 let sandbox: sinon.SinonSandbox;
-
 describe('TSS Suggestions', () => {
+	const provider = new StyleCompletionItemProvider();
+	async function testCompletion (position: vscode.Position): Promise<vscode.CompletionItem[]> {
+		const text = await vscode.workspace.openTextDocument(uri);
+		return provider.provideCompletionItems(text, position);
+	}
 
 	before(async function () {
 		this.timeout(5000);
 		sandbox = sinon.createSandbox();
-		sandbox.stub(project, 'sdk').returns([ '8.1.0.GA' ]);
-		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
+		sandbox.stub(provider, 'getProject').resolves(new Project('/test', 'app'));
+		sandbox.stub(provider, 'getCompletions').resolves(completions);
 	});
 
 	after(async function () {

--- a/src/test/unit/suite/viewAutoCompleteProvider.test.ts
+++ b/src/test/unit/suite/viewAutoCompleteProvider.test.ts
@@ -3,9 +3,8 @@ import * as fs from 'fs';
 import { after, before, describe, it } from 'mocha';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import * as tce from 'titanium-editor-commons';
+import { Project } from '../../../project';
 import * as vscode from 'vscode';
-import project from '../../../project';
 
 import { ViewCompletionItemProvider } from '../../../providers/completion/viewCompletionItemProvider';
 
@@ -15,20 +14,20 @@ const uri = vscode.Uri.file(xmlFile);
 const rawData = fs.readFileSync(path.join(fixturesPath, 'data', 'completions.json'), 'utf8');
 const completions = JSON.parse(rawData);
 
-async function testCompletion (position: vscode.Position): Promise<vscode.CompletionItem[]> {
-	const text = await vscode.workspace.openTextDocument(uri);
-	const provider = new ViewCompletionItemProvider();
-	return provider.provideCompletionItems(text, position);
-}
 let sandbox: sinon.SinonSandbox;
 
 describe('View suggestions', () => {
+	const provider = new ViewCompletionItemProvider();
 
+	async function testCompletion (position: vscode.Position): Promise<vscode.CompletionItem[]> {
+		const text = await vscode.workspace.openTextDocument(uri);
+		return provider.provideCompletionItems(text, position);
+	}
 	before(async function () {
 		this.timeout(5000);
 		sandbox = sinon.createSandbox();
-		sandbox.stub(project, 'sdk').returns([ '8.1.0.GA' ]);
-		sandbox.stub(tce.completion, 'loadCompletions').resolves(completions);
+		sandbox.stub(provider, 'getProject').resolves(new Project('/test', 'app'));
+		sandbox.stub(provider, 'getCompletions').resolves(completions);
 	});
 
 	after(async function () {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -364,10 +364,6 @@ export function matches (text: string, test: string): boolean {
 	return new RegExp(test, 'i').test(text);
 }
 
-export function isValidPlatform (targetPlatform: string): boolean {
-	return fs.pathExistsSync(path.join(workspace.rootPath!, targetPlatform));
-}
-
 /**
  * Determine the correct certificate name value to provide to the SDK build process.
  * Prior to SDK 8.2.0 only the "name" property was allowed, but for 8.2.0 and above

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -331,6 +331,7 @@ export function validateAppId (appId: string): boolean {
  * @returns {Boolean}
  */
 export function matches (text: string, test: string): boolean {
+	// eslint-disable-next-line security/detect-non-literal-regexp
 	return new RegExp(test, 'i').test(text);
 }
 
@@ -353,7 +354,11 @@ export function getCorrectCertificateName (certificateName: string, sdkVersion: 
 		throw new Error(`Failed to lookup certificate ${certificateName}`);
 	}
 
-	if (semver.gte(semver.coerce(sdkVersion)!, '8.2.0')) {
+	const coerced = semver.coerce(sdkVersion);
+
+	// If we cant coerce the SDK version just assume it's newer than 8.2.0 because lets be honest,
+	// it almost certainly is
+	if (!coerced || semver.gte(coerced, '8.2.0')) {
 		return certificate.fullname;
 	} else {
 		return certificate.name;


### PR DESCRIPTION
Each app/module project is detected in the workspace and will be handled correctly dependent on the scenario:

* Commands such as build/package/alloy generate will prompt for the folder that the command should be ran in
* Completions/definition/task providers will lookup the folder associated with the request and then gather the required information from that

For users who only ever have 1 project open this will mostly be transparent 

#157