### PR TITLE
fix(debug/android): improve reliability of Android debug attachment

### DIFF
--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -59,7 +59,7 @@ This will automatically generate two debug configurations in `.vscode/launch.jso
 | ------------- | ------------| ------------- | ---------- |
 | platform | Platform to debug | No Default | true |
 | projectDir | Directory of the Titanium project to debug | [${workspaceFolder}](https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables) | false |
-| port | Port number to use for the debugger | 9000 | false |
+| port | Port number to use for the debugger | No Default | false |
 | preLaunchTask | Name of the task to build the application | No Default | false |
 
 ### Specifying a pre-launch task

--- a/package.json
+++ b/package.json
@@ -136,8 +136,7 @@
               },
               "port": {
                 "type": "number",
-                "description": "Port number to use for the debugger",
-                "defaultValue": 9000
+                "description": "Port number to use for the debugger"
               },
               "preLaunchTask": {
                 "type": "string",

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -11,21 +11,10 @@ export async function determineProjectType (projectDirectory: string): Promise<'
 }
 
 export async function getAppName (projectDirectory: string): Promise<string> {
-	return new Promise((resolve, reject) => {
-		try {
-			const tiappPath = path.join(projectDirectory, 'tiapp.xml');
-			const fileData = fs.readFileSync(tiappPath, 'utf-8');
-			const parser = new xml2js.Parser();
-			parser.parseString(fileData, (err: Error, result: any) => {
-				if (!err) {
-					return resolve(result['ti:app'].name[0]);
-				}
-			});
-		} catch (error) {
-			return reject(error);
-		}
-	});
-
+	const tiappPath = path.join(projectDirectory, 'tiapp.xml');
+	const fileData = fs.readFileSync(tiappPath, 'utf-8');
+	const result = await parseXmlString(fileData) as { 'ti:app': { name: string[] }};
+	return result['ti:app'].name[0];
 }
 
 export function parseXmlString (xmlString: string): Promise<unknown> {

--- a/src/container.ts
+++ b/src/container.ts
@@ -21,6 +21,7 @@ export class ExtensionContainer {
 	private static _buildExplorer: DeviceExplorer;
 	private static _config: Config | undefined;
 	private static _context: vscode.ExtensionContext;
+	private static _debugPorts = new Map<string, number>();
 	private static _helpExplorer: HelpExplorer;
 	private static _projects: Map<string, Project> = new Map();
 	private static _runningTask: vscode.TaskExecution|undefined;
@@ -105,6 +106,10 @@ export class ExtensionContainer {
 
 	static get runningTasks (): Map<string, RunningTask> {
 		return this._runningTasks;
+	}
+
+	static get debugPorts(): Map<string, number> {
+		return this._debugPorts;
 	}
 
 	/**

--- a/src/debugger/titaniumDebugAdapter.ts
+++ b/src/debugger/titaniumDebugAdapter.ts
@@ -73,8 +73,11 @@ export class TitaniumDebugAdapter extends ChromeDebugAdapter {
 		return super.globalEvaluate(args);
 	}
 
-	private attachAndroid (attachArgs: TitaniumAttachRequestArgs): Promise<void> {
-		return super.attach(attachArgs);
+	private async attachAndroid (attachArgs: TitaniumAttachRequestArgs): Promise<void> {
+		// Rather than attaching straight away, wait for a small amount of time to allow the app
+		// to load and setup the debugger
+		await sleep(500);
+		await super.attach(attachArgs);
 	}
 
 	private async attachIOS (attachArgs: TitaniumAttachRequestArgs): Promise<void> {

--- a/src/project.ts
+++ b/src/project.ts
@@ -117,7 +117,6 @@ export class Project {
 	 */
 	private async loadTiappFile  (): Promise<void> {
 		this.isValidTiapp = false;
-		let error: InteractionError | undefined;
 		const filePath = path.join(this.filePath, TIAPP_FILENAME);
 
 		if (!await fs.pathExists(filePath)) {

--- a/src/tasks/buildTaskProvider.ts
+++ b/src/tasks/buildTaskProvider.ts
@@ -63,8 +63,7 @@ export class BuildTaskProvider extends CommandTaskProvider {
 						platform: platform as Platform,
 						projectType: 'app',
 						projectDir: folder.uri.fsPath,
-						liveview: false,
-						debugPort: 9000
+						liveview: false
 					},
 					label: name,
 					name,

--- a/src/tasks/helpers/android.ts
+++ b/src/tasks/helpers/android.ts
@@ -35,8 +35,12 @@ export class AndroidHelper extends TaskHelper {
 
 		await this.resolveCommonAppOptions(context, definition, builder);
 
-		if (definition.debugPort || definition.debug) {
-			builder.addOption('--debug-host', `/localhost:${definition.debugPort || '9000'}`);
+		if (definition.debug) {
+			const port = definition.debugPort || ExtensionContainer.debugPorts.get(definition.projectDir);
+			if (!port) {
+				throw new Error(`Failed to find debug port associated with ${definition.projectDir}. Please try setting a "port" property in the configuration.`);
+			}
+			builder.addOption('--debug-host', `/localhost:${port}`);
 		}
 
 		this.storeLastState(WorkspaceState.LastBuildState, definition);


### PR DESCRIPTION
This fixes a couple inconsistent issues around attaching to the Android debugger. It moves to using
a random port every time (unless specified by the user) due to an issue where a debug session could
fail to start due to the port already being in use, and adds a small delay to the attachment process
to allow time for the app to have got the debugger ready for attaching to