### PR TITLE
feat: add a command to generate a task for a device or distribution target

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4985,8 +4985,7 @@
     "detect-indent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
-      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
-      "dev": true
+      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA=="
     },
     "detect-libc": {
       "version": "1.0.3",
@@ -5397,7 +5396,7 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.12.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
           "dev": true,
           "requires": {
@@ -5412,7 +5411,7 @@
         },
         "@babel/highlight": {
           "version": "7.13.10",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
           "dev": true,
           "requires": {
@@ -5423,7 +5422,7 @@
           "dependencies": {
             "chalk": {
               "version": "2.4.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "dev": true,
               "requires": {
@@ -5442,13 +5441,13 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "chalk": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
@@ -5458,7 +5457,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.3.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "dev": true,
               "requires": {
@@ -5467,7 +5466,7 @@
             },
             "supports-color": {
               "version": "7.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "dev": true,
               "requires": {
@@ -5478,7 +5477,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -5487,13 +5486,13 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "cross-spawn": {
           "version": "7.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
@@ -5504,7 +5503,7 @@
         },
         "debug": {
           "version": "4.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
@@ -5519,7 +5518,7 @@
         },
         "eslint-visitor-keys": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
           "dev": true
         },
@@ -5531,13 +5530,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "ignore": {
           "version": "4.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
@@ -5548,25 +5547,25 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "path-key": {
           "version": "3.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
         "regexpp": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
           "dev": true
         },
         "shebang-command": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
@@ -5575,13 +5574,13 @@
         },
         "shebang-regex": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
@@ -5590,7 +5589,7 @@
         },
         "strip-json-comments": {
           "version": "3.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
         }
@@ -8538,6 +8537,11 @@
           "dev": true
         }
       }
+    },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
     },
     "jsonfile": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -281,6 +281,11 @@
         "category": "Titanium"
       },
       {
+        "command": "titanium.task.generate",
+        "title": "Generate task",
+        "category": "Titanium"
+      },
+      {
         "command": "titanium.updates.openReleaseNotes",
         "title": "Open release notes",
         "category": "Titanium",
@@ -603,6 +608,10 @@
         {
           "command": "titanium.updates.reveal",
           "when": "false"
+        },
+        {
+          "command": "titanium.task.generate",
+          "when": "false"
         }
       ],
       "editor/context": [
@@ -738,6 +747,10 @@
           "command": "titanium.updates.checkAll",
           "when": "view == titanium.view.helpExplorer && viewItem == UpdatesNode",
           "group": "inline"
+        },
+        {
+          "command": "titanium.task.generate",
+          "when": "view == titanium.view.buildExplorer && viewItem =~ /DeviceNode|DistributeNode/"
         }
       ]
     },
@@ -981,10 +994,12 @@
   },
   "dependencies": {
     "@awam/remotedebug-ios-webkit-adapter": "^0.4.3",
+    "detect-indent": "^6.0.0",
     "find-up": "^5.0.0",
     "fs-extra": "^10.0.0",
     "get-port": "^5.1.1",
     "got": "^9.6.0",
+    "jsonc-parser": "^3.0.0",
     "klaw-sync": "^6.0.0",
     "ms": "^2.1.3",
     "semver": "^7.3.5",

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -21,7 +21,7 @@ export enum Commands {
 	GenerateAlloyStyle = 'titanium.alloy.generate.style',
 	GenerateAlloyView = 'titanium.alloy.generate.view',
 	GenerateAlloyWidget = 'titanium.alloy.generate.widget',
-	GenerateAutocomplete = 'titanium.generate.autocompleteSuggestions',
+	GenerateTask = 'titanium.task.generate',
 	InstallAllUpdates = 'titanium.updates.installAll',
 	InstallUpdate = 'titanium.updates.install',
 	OpenAllRelatedFiles = 'titanium.alloy.open.allRelatedFiles',

--- a/src/commands/generateTask.ts
+++ b/src/commands/generateTask.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs-extra';
+import * as jsonc from 'jsonc-parser';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import detectIndent = require('detect-indent');
+import { ExtensionContainer } from '../container';
+import { enterAndroidKeystoreInfo, promptForWorkspaceFolder, selectiOSCertificate, selectiOSProvisioningProfile, yesNoQuestion } from '../quickpicks';
+import { TitaniumTaskDefinitionBase } from '../tasks/commandTaskProvider';
+import { nameForPlatform, nameForTarget } from '../utils';
+import { DeviceNode, DistributeNode } from '../explorer/nodes';
+import { AppBuildTaskDefinitionBase } from '../tasks/buildTaskProvider';
+import { AppPackageTaskDefinitionBase } from '../tasks/packageTaskProvider';
+import { ProjectType } from '../types/common';
+
+function isAppBuild (type: ProjectType, task: Partial<TitaniumTaskDefinitionBase>): task is AppBuildTaskDefinitionBase {
+	return type === 'app';
+}
+
+function isAppPackage (type: ProjectType, task: Partial<TitaniumTaskDefinitionBase>): task is AppPackageTaskDefinitionBase {
+	return type === 'app';
+}
+
+export async function generateTask (node: DeviceNode|DistributeNode): Promise<void> {
+	const { type, folder } = await promptForWorkspaceFolder({ apps: true, modules: false, placeHolder: 'Select a project to generate a task definition for' });
+
+	const tasksFileLocation = path.join(folder.uri.fsPath, '.vscode', 'tasks.json');
+	let fileContents;
+	if (await fs.pathExists(tasksFileLocation)) {
+		fileContents = await fs.readFile(tasksFileLocation, 'utf8');
+	} else {
+		fileContents = '{ "version" :"2.0.0", "tasks": [] }';
+	}
+
+	const project = ExtensionContainer.projects.get(folder.uri.fsPath);
+	if (!project) {
+		return;
+	}
+
+	const task: Partial<TitaniumTaskDefinitionBase> = {
+		label: `Titanium - ${nameForPlatform(node.platform)} ${nameForTarget(node.targetId)}`,
+		titaniumBuild: {
+			platform: node.platform,
+			projectType: type,
+			projectDir: folder.uri.fsPath
+		}
+	};
+
+	if (node instanceof DeviceNode && isAppBuild(type, task)) {
+		task.type = 'titanium-build';
+		task.titaniumBuild.deviceId = node.deviceId;
+		task.titaniumBuild.target = node.targetId;
+		if (node.platform === 'ios' && node.target === 'device') {
+			const selectSigning = await yesNoQuestion({ placeHolder: 'Select signing information?' });
+
+			if (selectSigning) {
+				const certificate = await selectiOSCertificate('run');
+				const provisioningProfile = await selectiOSProvisioningProfile(certificate, node.target, project.appId());
+
+				task.titaniumBuild.ios = {
+					certificate: certificate.fullname,
+					provisioningProfile: provisioningProfile.uuid
+				};
+			}
+		}
+	} else if (node instanceof DistributeNode && isAppPackage(type, task)) {
+		task.type = 'titanium-package';
+		task.titaniumBuild.target = node.targetId;
+		if (node.platform === 'ios') {
+			const selectSigning = await yesNoQuestion({ placeHolder: 'Select signing information?' });
+
+			if (selectSigning) {
+				const certificate = await selectiOSCertificate('package');
+				const provisioningProfile = await selectiOSProvisioningProfile(certificate, node.targetId, project.appId());
+
+				task.titaniumBuild.ios = {
+					certificate: certificate.fullname,
+					provisioningProfile: provisioningProfile.uuid
+				};
+			}
+		} else if (node.platform === 'android') {
+			const selectKeystore = await yesNoQuestion({ placeHolder: 'Select keystore information?' });
+
+			if (selectKeystore) {
+				const keystoreInfo = await enterAndroidKeystoreInfo(folder);
+				task.titaniumBuild.android = {
+					keystore: {
+						alias: keystoreInfo.alias,
+						location: keystoreInfo.location
+					}
+				};
+			}
+		}
+	}
+
+	try {
+		const indent = detectIndent(fileContents);
+		const formattingOptions: jsonc.FormattingOptions = { insertSpaces: indent.type === 'space', tabSize: indent.amount };
+
+		const edits = jsonc.modify(fileContents, [ 'tasks', 0 ], task, { isArrayInsertion: true, formattingOptions });
+		const editedContents = jsonc.applyEdits(fileContents, edits);
+		await fs.writeFile(tasksFileLocation, editedContents);
+
+		const choice = await vscode.window.showInformationMessage(`Generated task ${task.label}`, { title: 'Show' });
+
+		if (choice?.title === 'Show') {
+			const document = await vscode.workspace.openTextDocument(tasksFileLocation);
+			await vscode.window.showTextDocument(document);
+		}
+	} catch (error) {
+		vscode.window.showErrorMessage(`Failed to generate task ${error}`);
+	}
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,15 +1,16 @@
-import { ExtensionContainer } from '../container';
+import * as related from '../related';
 import * as vscode from 'vscode';
+
+import { ExtensionContainer } from '../container';
 import { Commands } from './common';
 import { GlobalState } from '../constants';
 import { buildApplication } from './buildApp';
 import { buildModule } from './buildModule';
-import { DeviceNode, OSVerNode, PlatformNode, TargetNode, UpdateNode } from '../explorer/nodes';
+import { DeviceNode, DistributeNode, OSVerNode, PlatformNode, TargetNode, UpdateNode } from '../explorer/nodes';
 import { sleep } from '../common/utils';
-import * as related from '../related';
 import { packageApplication } from './packageApp';
 import { packageModule } from './packageModule';
-import { quickPick } from '../quickpicks';
+import { promptForWorkspaceFolder, quickPick } from '../quickpicks';
 import { LogLevel } from '../types/common';
 import { configuration } from '../configuration';
 import { AlloyComponentExtension, AlloyComponentFolder, AlloyComponentType, generateComponent, generateModel } from './alloyGenerate';
@@ -19,7 +20,7 @@ import { createApplication } from './createApp';
 import { createModule } from './createModule';
 import { UpdateInfo } from 'titanium-editor-commons/updates';
 import { installUpdates } from '../updates';
-import { promptForWorkspaceFolder } from '../quickpicks/common';
+import { generateTask } from './generateTask';
 
 export function registerCommand (commandId: string, callback: (...args: any[]) => unknown): void {
 	ExtensionContainer.context.subscriptions.push(
@@ -173,6 +174,10 @@ export function registerCommands (): void {
 
 	registerCommand(Commands.InstallUpdate, (updateInfo: UpdateNode) => {
 		return installUpdates([ updateInfo.update ]);
+	});
+
+	registerCommand(Commands.GenerateTask, async (node: DeviceNode|DistributeNode) => {
+		return generateTask(node);
 	});
 }
 

--- a/src/explorer/helpExplorer.ts
+++ b/src/explorer/helpExplorer.ts
@@ -8,7 +8,7 @@ export class HelpExplorer implements vscode.TreeDataProvider<BaseNode> {
 
 	// tslint:disable-next-line member-ordering
 	public readonly onDidChangeTreeData: vscode.Event<BaseNode|undefined> = this._onDidChangeTreeData.event;
-	private updatesNode: UpdatesNode|undefined;
+	private updatesNode: UpdatesNode = new UpdatesNode('Updates');
 
 	public refresh (): void {
 		this._onDidChangeTreeData.fire(undefined);
@@ -29,7 +29,7 @@ export class HelpExplorer implements vscode.TreeDataProvider<BaseNode> {
 			new UrlNode('TiSlack', 'https://tislack.org', 'comment-discussion'),
 			new CommandNode('Report Extension Issue', VSCodeCommands.ReportIssue, [ ExtensionId ], 'report'),
 			new CommandNode('Configure Settings', VSCodeCommands.OpenSettings, [ `@ext:${ExtensionId}` ], 'settings-gear'),
-			this.updatesNode = new UpdatesNode('Updates')
+			this.updatesNode
 		];
 	}
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -5,9 +5,8 @@ import * as utils from './utils';
 
 import { Range, window, workspace } from 'vscode';
 import { handleInteractionError, InteractionError } from './commands/common';
-import { Platform } from './types/common';
+import { Platform, ProjectType } from './types/common';
 import { parseXmlString } from './common/utils';
-import { ProjectType } from './tasks/tasksHelper';
 
 const TIAPP_FILENAME = 'tiapp.xml';
 const TIMODULEXML_FILENAME = 'timodule.xml';

--- a/src/quickpicks.ts
+++ b/src/quickpicks.ts
@@ -1,4 +1,0 @@
-export * from './quickpicks/common';
-
-// export * from './quickpicks/build';
-export * from './quickpicks/creation';

--- a/src/quickpicks/common.ts
+++ b/src/quickpicks/common.ts
@@ -6,7 +6,7 @@ import { UpdateInfo } from 'titanium-editor-commons/updates';
 import { InputBoxOptions, QuickPickItem, QuickPickOptions, Uri, window, workspace, WorkspaceFolder } from 'vscode';
 import { UserCancellation } from '../commands/common';
 import { ExtensionContainer } from '../container';
-import { ProjectType } from '../tasks/tasksHelper';
+import { ProjectType } from '../types/common';
 
 export interface CustomQuickPick extends QuickPickItem {
 	label: string;

--- a/src/quickpicks/index.ts
+++ b/src/quickpicks/index.ts
@@ -1,0 +1,6 @@
+export * from './common';
+export * from './creation';
+
+export * from './build/android';
+export * from './build/common';
+export * from './build/ios';

--- a/src/tasks/commandTaskProvider.ts
+++ b/src/tasks/commandTaskProvider.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode';
-import { TaskExecutionContext, ProjectType } from './tasksHelper';
+import { TaskExecutionContext } from './tasksHelper';
 import { TaskPseudoTerminal } from './taskPseudoTerminal';
 import { TaskHelper, Helpers } from './helpers';
 import { UserCancellation, handleInteractionError, InteractionError, checkLogin } from '../commands/common';
-import { LogLevel, Platform } from '../types/common';
+import { LogLevel, Platform, ProjectType } from '../types/common';
 import { CommandError } from '../common/utils';
 import { Command } from './commandBuilder';
 

--- a/src/tasks/helpers/base.ts
+++ b/src/tasks/helpers/base.ts
@@ -1,4 +1,4 @@
-import { TaskExecutionContext, ProjectType, isDistributionAppBuild } from '../tasksHelper';
+import { TaskExecutionContext, isDistributionAppBuild } from '../tasksHelper';
 import { Command, CommandBuilder } from '../commandBuilder';
 import { ExtensionContainer } from '../../container';
 import { quickPick } from '../../quickpicks';
@@ -13,6 +13,7 @@ import { WorkspaceState } from '../../constants';
 import { selectDevice } from '../../quickpicks/build/common';
 import { IosBuildTaskTitaniumBuildBase } from './ios';
 import { Project } from '../../project';
+import { ProjectType } from '../../types/common';
 
 function isAppBuild<T extends TitaniumBuildBase>(definition: TitaniumBuildBase): definition is T {
 	if (definition.projectType === 'app') {

--- a/src/tasks/packageTaskProvider.ts
+++ b/src/tasks/packageTaskProvider.ts
@@ -11,6 +11,10 @@ export interface PackageTask extends TitaniumTaskBase {
 	definition: PackageTaskDefinitionBase;
 }
 
+export interface AppPackageTaskDefinitionBase extends TitaniumTaskDefinitionBase {
+	titaniumBuild: AppPackageTaskTitaniumBuildBase;
+}
+
 export interface PackageTaskDefinitionBase extends TitaniumTaskDefinitionBase {
 	titaniumBuild: AppPackageTaskTitaniumBuildBase | ModulePackageTaskTitaniumBuildBase;
 }

--- a/src/tasks/tasksHelper.ts
+++ b/src/tasks/tasksHelper.ts
@@ -8,7 +8,6 @@ import { TitaniumTaskBase, TitaniumTaskDefinitionBase } from './commandTaskProvi
 import { DeviceNode } from '../explorer/nodes';
 
 export type TitaniumTaskTypes = 'titanium-build' | 'titanium-package';
-export type ProjectType = 'app' | 'module';
 
 export interface RunningTask {
 	buildOptions: AppBuildTaskTitaniumBuildBase;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -64,3 +64,5 @@ export interface LastBuildState extends AppBuildTaskTitaniumBuildBase {
 	deviceId: string;
 	target: 'device' | 'emulator' | 'simulator';
 }
+
+export type ProjectType = 'app' | 'module';


### PR DESCRIPTION
This adds support for generating a task via the right click context menu, the data is then used
to construct a task object and then add it into the tasks.json file, creating on if necessary.

Part of #643

Also fixes an issue with the reveal updates command where the UpdatesNode was only created when the explorer was shown. Now it's created when the explorer is created and can always be accessed