### PR TITLE
ci: dont run integration tests on pull request or push, only nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,22 +39,3 @@ jobs:
         uses: GabrielBB/xvfb-action@v1.0
         with:
           run: npm run test
-
-  Integration-Test:
-    name: Integration Tests - latest VS Code
-    runs-on: macos-latest
-    needs: Lint
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: Install dependencies and requirements
-        run: |
-          npm ci
-          npm i titanium alloy -g
-          ti sdk install latest
-      - name: Run Integration Tests
-        run: npm run test:integration
-        env:
-          CODE_VERSION: latest


### PR DESCRIPTION
They're flaky in ci and make noise. Nightly if changes fits better now there are better unit tests