### PR TITLE
Support for vscode trusted workspaces and virtual workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,7 +135,7 @@
         },
         "which": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "requires": {
             "isexe": "^2.0.0"
@@ -869,6 +869,13 @@
         "resolve-global": "^1.0.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "12.20.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.13.tgz",
+          "integrity": "sha512-1x8W5OpxPq+T85OUsHRP6BqXeosKmeXRtjoF39STcdf/UWLqUsoehstZKOi0CunhVqHG17AyZgpj20eRVooK6A==",
+          "dev": true,
+          "optional": true
+        },
         "lodash": {
           "version": "4.17.14",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
@@ -1908,9 +1915,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.0.tgz",
-      "integrity": "sha512-6N8Sa5AaENRtJnpKXZgvc119PKxT1Lk9VPy4kfT8JF23tIe1qDfaGkBR2DRKJFIA7NptMz+fps//C6aLi1Uoug=="
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1988,9 +1995,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.49.0.tgz",
-      "integrity": "sha512-wfNQmLmm1VdMBr6iuNdprWmC1YdrgZ9dQzadv+l2eSjJlElOdJw8OTm4RU4oGTBcfvG6RZI2jOcppkdSS18mZw==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
+      "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
       "dev": true
     },
     "@types/which": {
@@ -5523,7 +5530,7 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.12.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
           "dev": true,
           "requires": {
@@ -5538,7 +5545,7 @@
         },
         "@babel/highlight": {
           "version": "7.13.10",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
           "dev": true,
           "requires": {
@@ -5549,7 +5556,7 @@
           "dependencies": {
             "chalk": {
               "version": "2.4.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "dev": true,
               "requires": {
@@ -5568,13 +5575,13 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "chalk": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
@@ -5584,7 +5591,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.3.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "dev": true,
               "requires": {
@@ -5593,7 +5600,7 @@
             },
             "supports-color": {
               "version": "7.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "dev": true,
               "requires": {
@@ -5604,7 +5611,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -5613,13 +5620,13 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "cross-spawn": {
           "version": "7.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
@@ -5630,7 +5637,7 @@
         },
         "debug": {
           "version": "4.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
@@ -5645,7 +5652,7 @@
         },
         "eslint-visitor-keys": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
           "dev": true
         },
@@ -5657,13 +5664,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "ignore": {
           "version": "4.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
         },
@@ -5674,25 +5681,25 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "path-key": {
           "version": "3.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
         "regexpp": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
           "dev": true
         },
         "shebang-command": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
           "dev": true,
           "requires": {
@@ -5701,13 +5708,13 @@
         },
         "shebang-regex": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
@@ -5716,7 +5723,7 @@
         },
         "strip-json-comments": {
           "version": "3.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
         }
@@ -15054,12 +15061,12 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "mkdirp": {
           "version": "0.5.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "requires": {
             "minimist": "^1.2.5"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": false
-    }
+    },
+    "virtualWorkspaces": false
   },
   "license": "Apache 2.0",
   "main": "./out/extension",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "url": "https://github.com/appcelerator/vscode-appcelerator-titanium.git"
   },
   "engines": {
-    "vscode": "^1.49.0",
-    "node": ">=12.4.0"
+    "vscode": "^1.56.0",
+    "node": ">=14.16.0"
   },
   "activationEvents": [
     "*",
@@ -42,6 +42,11 @@
     "workspaceContains:tiapp.xml",
     "workspaceContains:**/timodule.xml"
   ],
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false
+    }
+  },
   "license": "Apache 2.0",
   "main": "./out/extension",
   "contributes": {
@@ -475,16 +480,17 @@
         {
           "id": "titanium.view.welcome",
           "name": "Get Started",
-          "when": "!titanium:enabled"
+          "when": "!isWorkspaceTrusted || !titanium:enabled"
         },
         {
           "id": "titanium.view.buildExplorer",
           "name": "Build",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "id": "titanium.view.helpExplorer",
-          "name": "Help and Feedback"
+          "name": "Help and Feedback",
+          "when": "isWorkspaceTrusted"
         }
       ]
     },
@@ -498,83 +504,90 @@
         "view": "titanium.view.welcome",
         "contents": "To use the Titanium extension you must have a Titanium project open\n[Open Project](command:workbench.action.addRootFolder)\nYou can also create a new Application or Module project\n[Create App](command:titanium.create.application)\n[Create Module](command:titanium.create.module)",
         "when": "titanium:notProject"
+      },
+      {
+        "view": "titanium.view.welcome",
+        "contents": "Please trust this workspace to use the Titanium extension.\n[Manage Workspace Trust](command:workbench.trust.manage) [Learn more about Workspace Trust](https://aka.ms/vscode-workspace-trust)",
+        "when": "!isTrustedWorkspace"
       }
     ],
     "menus": {
       "commandPalette": [
         {
-          "command": "titanium.create.application"
+          "command": "titanium.create.application",
+          "when": "isWorkspaceTrusted"
         },
         {
-          "command": "titanium.create.module"
+          "command": "titanium.create.module",
+          "when": "isWorkspaceTrusted"
         },
         {
           "command": "titanium.explorer.refresh",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.build.setLiveViewEnabled",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.build.setLiveViewDisabled",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.build.run",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.package.run",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.build.stop",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.build.setLogLevel",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.alloy.open.relatedView",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.alloy.open.relatedStyle",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.alloy.open.relatedController",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.alloy.open.allRelatedFiles",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.alloy.generate.controller",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.alloy.generate.migration",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.alloy.generate.model",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.alloy.generate.style",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.alloy.generate.view",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.alloy.generate.widget",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.updates.openReleaseNotes",
@@ -586,7 +599,7 @@
         },
         {
           "command": "titanium.clean",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.build.debug",
@@ -597,13 +610,16 @@
           "when": "false"
         },
         {
-          "command": "titanium.updates.checkAll"
+          "command": "titanium.updates.checkAll",
+          "when": "isWorkspaceTrusted"
         },
         {
-          "command": "titanium.updates.installAll"
+          "command": "titanium.updates.installAll",
+          "when": "isWorkspaceTrusted"
         },
         {
-          "command": "titanium.updates.select"
+          "command": "titanium.updates.select",
+          "when": "isWorkspaceTrusted"
         },
         {
           "command": "titanium.updates.reveal",
@@ -636,22 +652,22 @@
         {
           "command": "titanium.alloy.generate.controller",
           "group": "2_workspace",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.alloy.generate.model",
           "group": "2_workspace",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.alloy.generate.style",
           "group": "2_workspace",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         },
         {
           "command": "titanium.alloy.generate.view",
           "group": "2_workspace",
-          "when": "titanium:enabled"
+          "when": "isWorkspaceTrusted && titanium:enabled"
         }
       ],
       "view/title": [
@@ -957,12 +973,12 @@
     "@types/klaw-sync": "^6.0.0",
     "@types/mocha": "^8.2.2",
     "@types/ms": "^0.7.31",
-    "@types/node": "12.12.0",
+    "@types/node": "14.14.31",
     "@types/semver": "^7.3.6",
     "@types/sinon": "^10.0.1",
     "@types/tmp": "^0.2.0",
     "@types/uuid": "^8.3.0",
-    "@types/vscode": "1.49.0",
+    "@types/vscode": "1.56.0",
     "@types/which": "^2.0.0",
     "@types/xml2js": "^0.4.8",
     "@typescript-eslint/eslint-plugin": "^4.26.0",

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -43,9 +43,9 @@ export class CommandError extends Error {
 	public command: string;
 	public exitCode: number;
 	public output?: string;
-	public signal?: string;
+	public signal?: NodeJS.Signals|null;
 
-	constructor(message: string, command: string, exitCode: number, output?: string, signal?: string) {
+	constructor(message: string, command: string, exitCode: number, output?: string, signal?: NodeJS.Signals|null) {
 		super(message);
 		this.command = command;
 		this.exitCode = exitCode;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,7 +16,8 @@ export enum GlobalState {
 	HasUpdates = 'titanium:update:hasUpdates',
 	RefreshEnvironment = 'titanium:environment:refresh',
 	MissingTooling = 'titanium:toolingMissing',
-	NotTitaniumProject = 'titanium:notProject'
+	NotTitaniumProject = 'titanium:notProject',
+	NeedsTrustedWorkspace = 'titanium:needsTrustedWorkspace'
 }
 
 export enum WorkspaceState {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,10 +50,9 @@ export async function activate (context: vscode.ExtensionContext): Promise<void>
 		await generateCompletions(false, project);
 	});
 
-}
-
-export function deactivate (): void {
-	// CLEANUP
+	vscode.workspace.onDidGrantWorkspaceTrust(async () => {
+		await startup();
+	});
 }
 
 /**
@@ -64,6 +63,14 @@ export function deactivate (): void {
  * we're installing from a missing tooling scenario
  */
 export async function startup (): Promise<void> {
+
+	if (!vscode.workspace.isTrusted) {
+		// We need to set Enabled here just incase are called by a change to the useTi setting
+		// where the environment was previously valid but now we are missing tooling
+		ExtensionContainer.setContext(GlobalState.Enabled, false);
+		ExtensionContainer.setContext(GlobalState.NeedsTrustedWorkspace, true);
+		return;
+	}
 
 	const { missing } = await environment.validateEnvironment(undefined, !ExtensionContainer.isUsingTi());
 


### PR DESCRIPTION
This add support for the upcoming workspace trust configuration, the support is rather blunt in
that the extension will not work unless the workspace has been trusted. This was chosen because
of the variety of ways this extensions works i.e. installing tooling, building project (which can
also have hooks that run code), so it made more sense to stick with the stricter and more secure
option

BREAKING CHANGE: Raises the minimum VS Code version to 1.56.0