### PR TITLE
feat: add keystore creation and keystore information storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1451,6 +1451,14 @@
         "@octokit/openapi-types": "^6.0.0"
       }
     },
+    "@redhat-developer/vscode-wizard": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@redhat-developer/vscode-wizard/-/vscode-wizard-0.2.9.tgz",
+      "integrity": "sha512-RnzuTs4rfenHGYRF1fN4RKZX8p8IifvYyHAyEEPfJtJ5UTXgJQn8Y0awps1VyCPVTe77w9Vdxd5wAu7/5qYBcw==",
+      "requires": {
+        "handlebars": "^4.7.3"
+      }
+    },
     "@seadub/danger-plugin-dependencies": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@seadub/danger-plugin-dependencies/-/danger-plugin-dependencies-1.0.0.tgz",
@@ -1587,6 +1595,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.18.tgz",
       "integrity": "sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==",
       "dev": true
+    },
+    "@types/chai-as-promised": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.4.tgz",
+      "integrity": "sha512-1y3L1cHePcIm5vXkh1DSGf/zQq5n5xDKG1fpCvf18+uOkpce0Z1ozNFPkyWsVswK7ntN1sZBw3oU6gmN+pDUcA==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -2850,6 +2867,15 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -2883,13 +2909,13 @@
       "dev": true
     },
     "cheerio": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.9.tgz",
-      "integrity": "sha512-QF6XVdrLONO6DXRF5iaolY+odmhj2CLj+xzNod7INPWMi/x9X4SOylH0S/vaPpX+AUU6t04s34SQNh7DbkuCng==",
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
       "dev": true,
       "requires": {
-        "cheerio-select": "^1.4.0",
-        "dom-serializer": "^1.3.1",
+        "cheerio-select": "^1.5.0",
+        "dom-serializer": "^1.3.2",
         "domhandler": "^4.2.0",
         "htmlparser2": "^6.1.0",
         "parse5": "^6.0.1",
@@ -2898,24 +2924,24 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
           "dev": true
         }
       }
     },
     "cheerio-select": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.4.0.tgz",
-      "integrity": "sha512-sobR3Yqz27L553Qa7cK6rtJlMDbiKPdNywtR95Sj/YgfpLfy0u6CGJuaBKe5YE/vTc23SCRKxWSdlon/w6I/Ew==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
+      "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
       "dev": true,
       "requires": {
-        "css-select": "^4.1.2",
-        "css-what": "^5.0.0",
+        "css-select": "^4.1.3",
+        "css-what": "^5.0.1",
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0",
-        "domutils": "^2.6.0"
+        "domutils": "^2.7.0"
       }
     },
     "child-process-promise": {
@@ -4165,9 +4191,9 @@
       }
     },
     "css-select": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.2.tgz",
-      "integrity": "sha512-nu5ye2Hg/4ISq4XqdLY2bEatAcLIdt3OYGFc9Tm9n7VSlFBcfRv0gBNksHRgSdUDQGtN3XrZ94ztW+NfzkFSUw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
       "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
@@ -4178,9 +4204,9 @@
       }
     },
     "css-what": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
-      "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
       "dev": true
     },
     "currently-unhandled": {
@@ -4581,13 +4607,13 @@
       }
     },
     "dom-serializer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
-      "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
       "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
+        "domhandler": "^4.2.0",
         "entities": "^2.0.0"
       }
     },
@@ -4607,9 +4633,9 @@
       }
     },
     "domutils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-      "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "dev": true,
       "requires": {
         "dom-serializer": "^1.0.1",
@@ -6784,7 +6810,6 @@
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -6796,20 +6821,17 @@
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "wordwrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         }
       }
     },
@@ -9550,9 +9572,9 @@
       "dev": true
     },
     "monaco-page-objects": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-1.5.3.tgz",
-      "integrity": "sha512-JXDLVDxVTfUrqvbG9BciPg4BXFbmCROT7VQBWO7J8aeOUQirRlLhFRM96aALomCyQDaC1Sp/kl5ZITox6OVHJQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/monaco-page-objects/-/monaco-page-objects-1.6.0.tgz",
+      "integrity": "sha512-H7blefPNRuZtBRYKvPvt74cWChxdbkUk4rkcUqdazHO3cV7zj9ZnU6dCfUfVRweW5jmGguNZUAT0Zp64oR0DCg==",
       "dev": true,
       "requires": {
         "clipboardy": "^2.0.0",
@@ -9677,8 +9699,7 @@
     "neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -10095,9 +10116,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
       "dev": true
     },
     "object-keys": {
@@ -12731,9 +12752,9 @@
       }
     },
     "ts-essentials": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.1.tgz",
-      "integrity": "sha512-8lwh3QJtIc1UWhkQtr9XuksXu3O0YQdEE5g79guDfhCaU1FWTDIEDZ1ZSx4HTHUmlJZ8L812j3BZQ4a0aOUkSA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.2.tgz",
+      "integrity": "sha512-qWPVC1xZGdefbsgFP7tPo+bsgSA2ZIXL1XeEe5M2WoMZxIOr/HbsHxP/Iv75IFhiMHMDGL7cOOwi5SXcgx9mHw==",
       "dev": true
     },
     "tsconfig-paths": {
@@ -12867,7 +12888,6 @@
       "version": "3.13.6",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
       "integrity": "sha512-rRprLwl8RVaS+Qvx3Wh5hPfPBn9++G6xkGlUupya0s5aDmNjI7z3lnRLB3u7sN4OmbB0pWgzhM9BEJyiWAwtAA==",
-      "dev": true,
       "optional": true
     },
     "unbox-primitive": {
@@ -13111,27 +13131,27 @@
       }
     },
     "vsce": {
-      "version": "1.88.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.88.0.tgz",
-      "integrity": "sha512-FS5ou3G+WRnPPr/tWVs8b/jVzeDacgZHy/y7/QQW7maSPFEAmRt2bFGUJtJVEUDLBqtDm/3VGMJ7D31cF2U1tw==",
+      "version": "1.93.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.93.0.tgz",
+      "integrity": "sha512-RgmxwybXenP6tTF0PLh97b/RRLp1RkzjAHNya3QAfv1EZVg+lfoBiAaXogpmOGjYr8OskkqP5tIa3D/Q6X9lrw==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^10.2.2",
         "chalk": "^2.4.2",
-        "cheerio": "^1.0.0-rc.1",
+        "cheerio": "^1.0.0-rc.9",
         "commander": "^6.1.0",
         "denodeify": "^1.2.1",
         "glob": "^7.0.6",
+        "ignore": "^5.1.8",
         "leven": "^3.1.0",
         "lodash": "^4.17.15",
         "markdown-it": "^10.0.0",
         "mime": "^1.3.4",
-        "minimatch": "^3.0.3",
         "osenv": "^0.1.3",
         "parse-semver": "^1.1.1",
         "read": "^1.0.7",
         "semver": "^5.1.0",
-        "tmp": "0.0.29",
+        "tmp": "^0.2.1",
         "typed-rest-client": "^1.8.4",
         "url-join": "^1.1.0",
         "yauzl": "^2.3.1",
@@ -13160,15 +13180,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
-        },
-        "tmp": {
-          "version": "0.0.29",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
         }
       }
     },
@@ -13235,9 +13246,9 @@
       "integrity": "sha512-ii7oCz3Wfr/SGtFr5AYop5dJm0dUmpg0hq2lTzTBdaht8nSheYMMjPntxULBR+2TUxXLcCKFZkF2UEJQduYsIQ=="
     },
     "vscode-extension-tester": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-4.0.3.tgz",
-      "integrity": "sha512-Bd4VelzQPJ5ogxEVwPR5dG7FyesgmAi2tqE74qlhTIgIIpQhZg7JlYEf2rRb6wWm/8b/s9LSSuls0QjhfLLOzQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-extension-tester/-/vscode-extension-tester-4.1.0.tgz",
+      "integrity": "sha512-xqFPZVDdveQIuUOae/CyH1VZysDUP1RmwdlBCowbRiemhPy+yzbE2Lr0ogYBTsFu4n754L1zAhIPzxnBrc8liA==",
       "dev": true,
       "requires": {
         "@types/selenium-webdriver": "^3.0.15",
@@ -13246,14 +13257,14 @@
         "fs-extra": "^9.0.1",
         "glob": "^7.1.6",
         "js-yaml": "^3.13.1",
-        "monaco-page-objects": "^1.5.3",
+        "monaco-page-objects": "^1.6.0",
         "request": "^2.88.0",
         "sanitize-filename": "^1.6.3",
         "selenium-webdriver": "^3.0.0",
         "targz": "^1.0.1",
         "unzip-stream": "^0.3.0",
         "vsce": "^1.81.0",
-        "vscode-extension-tester-locators": "^1.54.2"
+        "vscode-extension-tester-locators": "^1.57.0"
       },
       "dependencies": {
         "commander": {
@@ -13299,9 +13310,9 @@
       }
     },
     "vscode-extension-tester-locators": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-1.54.2.tgz",
-      "integrity": "sha512-N7R8s5Zq2ONIRc83UHziEFobDN8bjetaC8TKO47JZRV7dzo/6/f4dLzoO8m7Z4x58VNo+H2/DxW3gq37wIaBfg==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/vscode-extension-tester-locators/-/vscode-extension-tester-locators-1.57.0.tgz",
+      "integrity": "sha512-UH05MOGZfcvgM1sX4/YZgtsTRbXRDj8CPw/pcmoeJIC682bQXNizDwzQWmoEU/0U0jgn+AFlPE/gZV0GtIY/SA==",
       "dev": true
     },
     "vscode-extension-tester-native": {

--- a/package.json
+++ b/package.json
@@ -513,7 +513,7 @@
       },
       {
         "view": "titanium.view.welcome",
-        "contents": "Please trust this workspace to use the Titanium extension.\n[Manage Workspace Trust](command:workbench.trust.manage) [Learn more about Workspace Trust](https://aka.ms/vscode-workspace-trust)",
+        "contents": "Please trust this workspace to use the Titanium extension.\n[Manage Workspace Trust](command:workbench.trust.manage)\n[Learn more about Workspace Trust](https://aka.ms/vscode-workspace-trust)",
         "when": "!isTrustedWorkspace"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -180,6 +180,11 @@
         "description": "Create a new Titanium application project"
       },
       {
+        "command": "titanium.create.keystore",
+        "title": "Create keystore",
+        "category": "Titanium"
+      },
+      {
         "command": "titanium.create.module",
         "title": "Create module",
         "category": "Titanium",
@@ -516,6 +521,10 @@
       "commandPalette": [
         {
           "command": "titanium.create.application",
+          "when": "isWorkspaceTrusted"
+        },
+        {
+          "command": "titanium.create.keystore",
           "when": "isWorkspaceTrusted"
         },
         {
@@ -968,6 +977,7 @@
     "@seadub/danger-plugin-eslint": "^2.0.0",
     "@seadub/danger-plugin-junit": "^0.2.0",
     "@types/chai": "^4.2.18",
+    "@types/chai-as-promised": "^7.1.4",
     "@types/fs-extra": "^9.0.11",
     "@types/glob": "^7.1.3",
     "@types/got": "^9.6.11",
@@ -985,6 +995,7 @@
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "@typescript-eslint/parser": "^4.26.0",
     "chai": "^4.3.4",
+    "chai-as-promised": "^7.1.1",
     "commitizen": "^4.2.4",
     "cross-env": "^7.0.3",
     "cz-conventional-changelog": "^3.3.0",
@@ -1007,12 +1018,13 @@
     "standard-version": "^9.3.0",
     "tmp": "^0.2.1",
     "typescript": "^4.3.2",
-    "vscode-extension-tester": "^4.0.3",
+    "vscode-extension-tester": "^4.1.0",
     "vscode-extension-tester-native": "^3.0.2",
     "vscode-test": "^1.5.2"
   },
   "dependencies": {
     "@awam/remotedebug-ios-webkit-adapter": "^0.4.3",
+    "@redhat-developer/vscode-wizard": "^0.2.9",
     "detect-indent": "^6.1.0",
     "find-up": "^5.0.0",
     "fs-extra": "^10.0.0",

--- a/src/appc.ts
+++ b/src/appc.ts
@@ -391,6 +391,12 @@ export class Appc {
 		}
 	}
 
+	public getKeytoolPath (): string|undefined {
+		if (this.info?.jdk.executables.keytool) {
+			return this.info?.jdk.executables.keytool;
+		}
+	}
+
 	/**
 	 * Returns appc CLI session for current user.
 	 *

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -11,6 +11,7 @@ export enum Commands {
 	CheckForUpdates = 'titanium.updates.checkAll',
 	Clean = 'titanium.clean',
 	CreateApp = 'titanium.create.application',
+	CreateKeystore = 'titanium.create.keystore',
 	CreateModule = 'titanium.create.module',
 	Debug = 'titanium.build.debug',
 	DisableLiveView = 'titanium.build.setLiveViewDisabled',

--- a/src/commands/createKeystore.ts
+++ b/src/commands/createKeystore.ts
@@ -1,0 +1,286 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import Appc from '../appc';
+import { ExtensionContainer } from '../container';
+import { ValidatorResponse, WebviewWizard, WizardDefinition, WizardPageSectionDefinition } from '@redhat-developer/vscode-wizard';
+import { PerformFinishResponse } from '@redhat-developer/vscode-wizard/lib/IWizardWorkflowManager';
+import { getValidWorkspaceFolders, quickPick } from '../quickpicks';
+import { BUTTONS, SEVERITY } from '@redhat-developer/vscode-wizard/lib/WebviewWizard';
+import { KeystoreInfo } from '../types/common';
+import { CommandBuilder } from '../tasks/commandBuilder';
+
+export async function createKeystore (): Promise<KeystoreInfo> {
+
+	// eslint-disable-next-line no-async-promise-executor
+	return new Promise(async (resolve, reject) => {
+		interface KeystoreCreationProps {
+			storeInformation: boolean;
+			// Keystore details
+			password: string;
+			confirmPassword: string;
+			// Key Pair details
+			alias: string;
+			validity: string;
+			// Certificate details
+			name: string;
+			org: string;
+			orgUnit: string;
+			city: string;
+			state: string;
+			country: string;
+		}
+
+		let folder: string;
+		const choices = [
+			{
+				id: 'browse',
+				label: 'Browse for location'
+			}
+		];
+
+		for (const workspaceFolder of await getValidWorkspaceFolders()) {
+			choices.push({
+				id: workspaceFolder.folder.uri.fsPath,
+				label: workspaceFolder.folder.name,
+			});
+		}
+
+		const choice = await quickPick(choices, { placeHolder: 'Select an open project to create the keystore in or browse for folder' }, { forceShow: true });
+
+		if (choice.id === 'browse') {
+			const selection = await vscode.window.showOpenDialog({ canSelectFolders: true, canSelectFiles: false, canSelectMany: false });
+
+			if (!selection) {
+				await vscode.window.showErrorMessage('No folder was selected');
+				return;
+			}
+
+			folder = selection[0].fsPath;
+		} else {
+			folder = choice.id;
+		}
+
+		const keystorePath = path.join(folder, 'keystore');
+
+		if (await fs.pathExists(keystorePath)) {
+			vscode.window.showErrorMessage(`Keystore already exists at ${keystorePath}. Please delete it or choose a new location`);
+			return reject();
+		}
+
+		const def: WizardDefinition = {
+			title: 'Create Keystore',
+			description: 'Create a Keystore',
+			hideWizardHeader: true,
+			buttons: [ { id: BUTTONS.FINISH, label: 'Create' } ],
+			pages: [
+				{
+					id: 'create',
+					title: '',
+					description: '',
+					fields: [
+						{
+							id: 'store',
+							label: 'Store Keystore information',
+							description: 'This information is securely stored on your machine',
+							childFields: [
+								{
+									id: 'storeInformation',
+									type: 'checkbox',
+									label: ''
+								}
+							]
+						},
+						{
+							id: 'keystore',
+							label: 'Keystore Details',
+							childFields: [
+								{
+									id: 'password',
+									type: 'password',
+									label: 'Keystore Password'
+								},
+								{
+									id: 'confirmPassword',
+									type: 'password',
+									label: 'Confirm Keystore Password'
+								}
+							]
+						},
+						{
+							id: 'keypair',
+							label: 'Key Pair Details',
+							childFields: [
+								{
+									id: 'alias',
+									type: 'textbox',
+									label: 'Alias'
+								},
+								{
+									id: 'validity',
+									type: 'number',
+									label: 'Validity (years)',
+									initialValue: '25'
+								}
+							]
+						},
+						{
+							id: 'certificate',
+							label: 'Certificate Details',
+							childFields: [
+								{
+									id: 'name',
+									type: 'textbox',
+									label: 'First and Last Name'
+								},
+								{
+									id: 'orgUnit',
+									type: 'textbox',
+									label: 'Organizational Unit'
+								},
+								{
+									id: 'org',
+									type: 'textbox',
+									label: 'Organization'
+								},
+								{
+									id: 'city',
+									type: 'textbox',
+									label: 'City or Locality'
+								},
+								{
+									id: 'state',
+									type: 'textbox',
+									label: 'State or Province'
+								},
+								{
+									id: 'country',
+									type: 'textbox',
+									label: 'Country Code (XX)'
+								}
+							]
+						}
+					],
+					validator (parameters: KeystoreCreationProps) {
+						const response: ValidatorResponse = {
+							items: []
+						};
+
+						// Validate matching passwords
+						const password = parameters.password;
+						const confirmPassword = parameters.confirmPassword;
+
+						// eslint-disable-next-line security/detect-possible-timing-attacks
+						if (password !== confirmPassword) {
+							response.items.push({
+								template: {
+									id: 'confirmPasswordValidation',
+									content: 'Keystore password and confirmation do not match'
+								},
+								severity: SEVERITY.ERROR
+							});
+						}
+
+						const validity = parseInt(parameters.validity, 10);
+						if (validity && (!Number.isInteger(validity) || validity <= 0)) {
+							response.items.push({
+								template: {
+									id: 'validityValidation',
+									content: 'Validity must be a whole number above 0'
+								},
+								severity: SEVERITY.ERROR
+							});
+						}
+
+						const country = parameters.country;
+						if (country && country.length > 2) {
+							response.items.push({
+								template: {
+									id: 'countryValidation',
+									content: 'Country must be in a 2 character country code format'
+								},
+								severity: SEVERITY.ERROR
+							});
+						}
+
+						return response;
+					}
+				}
+			],
+			workflowManager: {
+				canFinish(wizard: WebviewWizard, data: KeystoreCreationProps): boolean {
+					// Validate that all the fields have been provided
+					let canFinish = true;
+					const { fields } = def.pages[0];
+					for (const field of fields) {
+						for (const { id, type } of (field as WizardPageSectionDefinition).childFields) {
+							if (type !== 'checkbox' && !data[id as keyof KeystoreCreationProps]) {
+								canFinish = false;
+							}
+						}
+					}
+
+					return canFinish;
+				},
+				async performFinish (wizard: WebviewWizard, data: KeystoreCreationProps): Promise<PerformFinishResponse|null> {
+					const keytool = Appc.getKeytoolPath();
+					if (!keytool) {
+						return null;
+					}
+
+					// Validity has to be specified in days
+					const validity =  parseInt(data.validity, 10) * 365;
+					try {
+						const commandInfo = CommandBuilder
+							.create(keytool, '-genkeypair', '-keyalg', 'RSA', '-validity', `${validity}`)
+							.addEnvironmentArgument('-alias', data.alias)
+							.addEnvironmentArgument('-dname', `CN=${data.name},OU=${data.orgUnit},O=${data.org},L=${data.city},ST=${data.state},C=${data.country}`, true)
+							.addEnvironmentArgument('-keypass', data.password, false, 'KEYPASS')
+							.addEnvironmentArgument('-storepass', data.password, false, 'KEYPASS')
+							.addEnvironmentArgument('-keystore', keystorePath)
+							.resolve();
+
+						await ExtensionContainer.terminal.runInBackground(keytool, commandInfo.args, { env: commandInfo.environment });
+					} catch (error) {
+
+						// eslint-disable-next-line promise/catch-or-return
+						vscode.window.showErrorMessage('There was an error creating the keystore', 'View')
+							.then(view => {
+								if (view) {
+									const output = vscode.window.createOutputChannel('Titanium - Keystore creation');
+									output.appendLine(error.command);
+									output.appendLine(error.output);
+									output.show();
+								}
+								return;
+							});
+						reject(error);
+						return {
+							close: false,
+							templates: [],
+							returnObject: {}
+						};
+					}
+
+					const storeProps = {
+						location: keystorePath,
+						alias: data.alias,
+						password: data.password,
+						privateKeyPassword: data.password
+					};
+
+					if (data.storeInformation) {
+						await ExtensionContainer.context.secrets.store(keystorePath, JSON.stringify(storeProps));
+					}
+
+					resolve(storeProps);
+					return null;
+				}
+			}
+		};
+
+		const wizard = new WebviewWizard('Create Keystore', 'Create Keystore', ExtensionContainer.context, def, new Map());
+		wizard.open();
+	});
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -21,6 +21,7 @@ import { createModule } from './createModule';
 import { UpdateInfo } from 'titanium-editor-commons/updates';
 import { installUpdates } from '../updates';
 import { generateTask } from './generateTask';
+import { createKeystore } from './createKeystore';
 
 export function registerCommand (commandId: string, callback: (...args: any[]) => unknown): void {
 	ExtensionContainer.context.subscriptions.push(
@@ -178,6 +179,10 @@ export function registerCommands (): void {
 
 	registerCommand(Commands.GenerateTask, async (node: DeviceNode|DistributeNode) => {
 		return generateTask(node);
+	});
+
+	registerCommand(Commands.CreateKeystore, async () => {
+		return createKeystore();
 	});
 }
 

--- a/src/quickpicks/build/android.ts
+++ b/src/quickpicks/build/android.ts
@@ -1,13 +1,14 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import appc from '../../appc';
-import { enterPassword, inputBox, quickPick } from '../common';
+import { enterPassword, inputBox, quickPick, yesNoQuestion } from '../common';
 import { UserCancellation } from '../../commands';
 import { pathExists } from 'fs-extra';
 import { ExtensionContainer } from '../../container';
 import { KeystoreInfo } from '../../types/common';
 import { deviceQuickPick, DeviceQuickPickItem } from './common';
 import { WorkspaceState } from '../../constants';
+import { createKeystore } from '../../commands/createKeystore';
 
 export function selectAndroidDevice (): Promise<DeviceQuickPickItem> {
 	const devices = appc.androidDevices().map(({ id, name }: { id: string; name: string }) => ({ id, label: name, udid: id }));
@@ -37,11 +38,17 @@ export function selectAndroidEmulator (): Promise<DeviceQuickPickItem>  {
 	return deviceQuickPick(options, { placeHolder: 'Select emulator' });
 }
 
-export async function selectAndroidKeystore (workspaceFolder: vscode.WorkspaceFolder, lastUsed?: string, savedKeystorePath?: string): Promise<string|undefined> {
-	const items = [ {
-		label: 'Browse for keystore',
-		id: 'browse'
-	} ];
+export async function selectAndroidKeystore (workspaceFolder: vscode.WorkspaceFolder, lastUsed?: string, savedKeystorePath?: string): Promise<string|KeystoreInfo> {
+	const items = [
+		{
+			label: 'Browse for keystore',
+			id: 'browse'
+		},
+		{
+			label: 'Create keystore',
+			id: 'create'
+		}
+	];
 	if (lastUsed) {
 		items.push({
 			label: `Last used ${lastUsed}`,
@@ -54,7 +61,7 @@ export async function selectAndroidKeystore (workspaceFolder: vscode.WorkspaceFo
 			id: 'saved'
 		});
 	}
-	const keystoreAction = await quickPick(items, { placeHolder: 'Browse for keystore or use last keystore' });
+	const keystoreAction = await quickPick(items, { placeHolder: 'Browse, create, or use last keystore' });
 	if (keystoreAction.id === 'browse') {
 		const uri = await vscode.window.showOpenDialog({ canSelectFolders: false, canSelectMany: false });
 		if (!uri) {
@@ -66,11 +73,24 @@ export async function selectAndroidKeystore (workspaceFolder: vscode.WorkspaceFo
 			savedKeystorePath = path.resolve(workspaceFolder.uri.fsPath, savedKeystorePath);
 		}
 		return savedKeystorePath;
+	} else if (keystoreAction.id === 'create') {
+		return createKeystore();
 	} else if (lastUsed) {
 		return lastUsed;
+	} else {
+		throw new Error('No keystore was selected');
 	}
 }
 
+/**
+ * Verifies whether there is a keystore at the provided path, if the provided path is not absolute
+ * (i.e it may have come from a user defined task) then it will be resolved based on the chosen
+ * workspace folder
+ *
+ * @param {string} keystorePath - The keystore path
+ * @param {vscode.WorkspaceFolder} folder - The Workspace folder for the projecy
+ * @returns {Promise<string>}
+ */
 async function resolveKeystorePath (keystorePath: string, folder: vscode.WorkspaceFolder): Promise<string> {
 	if (path.isAbsolute(keystorePath) && await pathExists(keystorePath)) {
 		return keystorePath;
@@ -85,14 +105,17 @@ async function resolveKeystorePath (keystorePath: string, folder: vscode.Workspa
 	throw new Error(`Provided keystorePath value "${keystorePath}" does not exist`);
 }
 
-async function verifyKeystorePath (keystorePath: string|undefined, folder: vscode.WorkspaceFolder): Promise<string> {
-	if (!keystorePath) {
-		throw new Error('Expected a value for keystorePath');
+/**
+ * Checks to see whether there is information stored for the provided keystore location
+ *
+ * @param {string} location - The location of the keystore
+ * @returns {(Promise<KeystoreInfo|undefined>)}
+ */
+async function lookupStoredInformation(location: string): Promise<KeystoreInfo|undefined> {
+	const information = await ExtensionContainer.context.secrets.get(location);
+	if (information) {
+		return JSON.parse(information);
 	}
-
-	const resolvedPath = await resolveKeystorePath(keystorePath, folder);
-
-	return resolvedPath;
 }
 
 export async function enterAndroidKeystoreInfo (workspaceFolder: vscode.WorkspaceFolder, keystoreInfo: Partial<KeystoreInfo> = {}): Promise<KeystoreInfo> {
@@ -100,11 +123,39 @@ export async function enterAndroidKeystoreInfo (workspaceFolder: vscode.Workspac
 	const lastUsed = ExtensionContainer.context.workspaceState.get<string>(WorkspaceState.LastKeystorePath);
 	const savedKeystorePath = ExtensionContainer.config.android.keystorePath;
 
-	if (!keystoreInfo?.location) {
-		keystoreInfo.location = await selectAndroidKeystore(workspaceFolder, lastUsed, savedKeystorePath);
+	if (!keystoreInfo.location) {
+		const selectedKeystore = await selectAndroidKeystore(workspaceFolder, lastUsed, savedKeystorePath);
+		if (typeof selectedKeystore === 'string') {
+			keystoreInfo.location = selectedKeystore;
+		} else {
+			Object.assign(keystoreInfo, selectedKeystore);
+		}
 	}
 
-	await verifyKeystorePath(keystoreInfo.location, workspaceFolder);
+	if (!keystoreInfo.location) {
+		throw new Error('No keystore was selected');
+	}
+
+	await resolveKeystorePath(keystoreInfo.location, workspaceFolder);
+
+	const storedInformation = await lookupStoredInformation(keystoreInfo.location);
+
+	if (storedInformation) {
+		// eslint-disable-next-line promise/catch-or-return
+		vscode.window.showInformationMessage(`Using stored information for ${keystoreInfo.location}. If this is unexpected or your build errors, clear this information using the button below`, 'Delete Information')
+			.then(async del => {
+				if (del) {
+					if (!keystoreInfo.location) {
+						return vscode.window.showErrorMessage('No keystore location was provided, so could not delete');
+					}
+					await ExtensionContainer.context.secrets.delete(keystoreInfo.location);
+					await vscode.window.showInformationMessage(`Deleted stored information for ${keystoreInfo.location}`);
+				}
+				return;
+			});
+
+		Object.assign(keystoreInfo, storedInformation);
+	}
 
 	if (!keystoreInfo.alias) {
 		keystoreInfo.alias = await inputBox({ placeHolder: 'Enter your keystore alias', value: ExtensionContainer.config.android.keystoreAlias || '' });
@@ -116,6 +167,14 @@ export async function enterAndroidKeystoreInfo (workspaceFolder: vscode.Workspac
 
 	if (!keystoreInfo.privateKeyPassword) {
 		keystoreInfo.privateKeyPassword = await enterPassword({ placeHolder: 'Enter your keystore private key password (optional)' });
+	}
+
+	if (!storedInformation) {
+		const store = await yesNoQuestion({ placeHolder: 'Would you like to store this information?' });
+
+		if (store) {
+			ExtensionContainer.context.secrets.store(keystoreInfo.location, JSON.stringify(keystoreInfo));
+		}
 	}
 
 	ExtensionContainer.context.workspaceState.update(WorkspaceState.LastKeystorePath, keystoreInfo.location);

--- a/src/tasks/commandBuilder.ts
+++ b/src/tasks/commandBuilder.ts
@@ -41,11 +41,11 @@ export class CommandBuilder {
 		return this;
 	}
 
-	private toEnvironmentArg (value: string) {
+	private toEnvironmentArg (value: string, quote = false) {
 		if (process.platform === 'win32') {
 			return `%${value}%`;
 		} else {
-			return `$${value}`;
+			return quote ? `"$${value}"` : `$${value}`;
 		}
 	}
 
@@ -75,10 +75,9 @@ export class CommandBuilder {
 		return this;
 	}
 
-	public addEnvironmentArgument(option: string, value: string): CommandBuilder {
-		const environmentName = option.replace(/-/g, '').toUpperCase();
+	public addEnvironmentArgument(option: string, value: string, quote = false, environmentName = option.replace(/-/g, '').toUpperCase()): CommandBuilder {
 		this.environmentOptions[environmentName] = value;
-		this.addOption(option, this.toEnvironmentArg(environmentName));
+		this.addOption(option, this.toEnvironmentArg(environmentName, quote));
 
 		return this;
 	}

--- a/src/tasks/commandBuilder.ts
+++ b/src/tasks/commandBuilder.ts
@@ -43,7 +43,7 @@ export class CommandBuilder {
 
 	private toEnvironmentArg (value: string, quote = false) {
 		if (process.platform === 'win32') {
-			return `%${value}%`;
+			return quote ? `"%${value}%"` : `%${value}%`;
 		} else {
 			return quote ? `"$${value}"` : `$${value}`;
 		}

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -46,12 +46,17 @@ export default class Terminal {
 			});
 
 			proc.stderr?.on('data', data => {
+				data = data.toString();
 				output += data.toString();
+				// If we're prompted for some info, error out
+				if (data.match(/Enter .+:/)) {
+					proc.kill(1);
+				}
 			});
 
 			proc.on('close', code => {
 				if (code) {
-					const error = new CommandError('Failed to run command', `${command} ${args}`, code, output);
+					const error = new CommandError('Failed to run command', `${command} ${args.join(' ')}`, code, output);
 					return reject(error);
 				}
 				return resolve({ output });

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -39,7 +39,7 @@ export default class Terminal {
 			spawnOptions.shell = true;
 		}
 		return new Promise((resolve, reject) => {
-			const proc = spawn(command, args, spawnOptions);
+			const proc = spawn(`"${command}"`, args, spawnOptions);
 			let output = ';';
 			proc.stdout?.on('data', data => {
 				output += data.toString();

--- a/src/test/integration/fixtures/settings.json
+++ b/src/test/integration/fixtures/settings.json
@@ -1,3 +1,4 @@
 {
-	"titanium.general.useTi": true
+	"titanium.general.useTi": true,
+	"security.workspace.trust.enabled": true
 }

--- a/src/test/integration/suite/alloy/generate.test.ts
+++ b/src/test/integration/suite/alloy/generate.test.ts
@@ -28,7 +28,6 @@ describe('Alloy component generation', function () {
 		tempDirectory = tmp.dirSync();
 		await generator.reset();
 		await copy(projectDirectory, tempDirectory.name);
-		await generator.waitForGetStarted();
 		await generator.openFolder(tempDirectory.name);
 		await driver.sleep(1000);
 		await generator.waitForEnvironmentDetectionCompletion();

--- a/src/test/integration/suite/keystore/create.test.ts
+++ b/src/test/integration/suite/keystore/create.test.ts
@@ -1,0 +1,74 @@
+import * as fs from 'fs-extra';
+import * as tmp from 'tmp';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { EditorView, InputBox, VSBrowser, WebDriver, WebView, By } from 'vscode-extension-tester';
+import { dismissNotifications, CommonUICreator } from '../../util/common';
+import { getCommonAlloyProjectDirectory } from '../../../common/utils';
+import { basename, join } from 'path';
+
+describe('Keystore creation', function () {
+	this.timeout(30000);
+
+	chai.use(chaiAsPromised);
+	const { expect } = chai;
+
+	const projectDirectory = getCommonAlloyProjectDirectory();
+	let browser: VSBrowser;
+	let driver: WebDriver;
+	let tempDirectory: tmp.DirResult;
+	let creator: CommonUICreator;
+	let webview: WebView|undefined;
+
+	before(async function () {
+		this.timeout(180000);
+		browser = VSBrowser.instance;
+		driver = browser.driver;
+		const editorView = new EditorView();
+		await editorView.closeAllEditors();
+		await browser.waitForWorkbench();
+		tempDirectory = tmp.dirSync();
+		creator = new CommonUICreator(driver);
+		await dismissNotifications();
+		await fs.copy(projectDirectory, tempDirectory.name);
+		await creator.openFolder(tempDirectory.name);
+		await creator.waitForGetStarted();
+	});
+
+	afterEach(async () => {
+		if (webview) {
+			await webview.switchBack();
+			webview = undefined;
+		}
+	});
+
+	it('should create a keystore', async () => {
+
+		await creator.workbench.executeCommand('Titanium: Create keystore');
+
+		const input = await InputBox.create();
+		await input.setText(basename(tempDirectory.name));
+		await input.confirm();
+		await driver.sleep(1000);
+
+		webview = new WebView();
+		await webview.switchToFrame();
+		(await webview.findWebElement(By.id('password'))).sendKeys('apassword');
+		const validation = await webview.findWebElement(By.id('confirmPasswordValidation'));
+		expect(validation.getText()).to.eventually.include('Keystore password and confirmation do not match');
+		(await webview.findWebElement(By.id('confirmPassword'))).sendKeys('apassword');
+		(await webview.findWebElement(By.id('alias'))).sendKeys('tester');
+		(await webview.findWebElement(By.id('name'))).sendKeys('Tester Test');
+		(await webview.findWebElement(By.id('orgUnit'))).sendKeys('Tester & Test Co.');
+		(await webview.findWebElement(By.id('org'))).sendKeys('Testing');
+		(await webview.findWebElement(By.id('city'))).sendKeys('Testing');
+		(await webview.findWebElement(By.id('state'))).sendKeys('Testing');
+		(await webview.findWebElement(By.id('country'))).sendKeys('TE');
+		await driver.sleep(2500);
+		(await webview.findWebElement(By.id('buttonFinish'))).click();
+
+		await driver.sleep(1000);
+
+		expect(fs.pathExistsSync(join(tempDirectory.name, 'keystore'))).to.equal(true, 'Keystore did not get created');
+	});
+});

--- a/src/types/environment-info.ts
+++ b/src/types/environment-info.ts
@@ -80,4 +80,20 @@ export interface AppcInfo {
 		version: string;
 		selectedSDK: string;
 	};
+	jdk: {
+		jdks: {
+			[key: string]: {
+				home: string;
+				version: string;
+				build: string;
+				executables: {
+					[key: string]: string
+				},
+				architecture: string
+			};
+		};
+		executables: {
+			[key: string]: string
+		},
+	}
 }


### PR DESCRIPTION
This adds support for creating a keystore and storing the keystore information. When packaging an
Android application there is now an extra "Create keystore" option. This will trigger a UI where
the information can be input, and optionally saved.

Also, when packaging for Android an extra "store information" dialog will be shown, this will store
the keystore information, using the path as they key, using the secure storage for the device.

Closes #89