### PR TITLE
build(deps): update to typescript 4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "sinon-chai": "^3.7.0",
         "standard-version": "^9.3.1",
         "tmp": "^0.2.1",
-        "typescript": "^4.3.5",
+        "typescript": "^4.4.2",
         "vscode-extension-tester": "^4.1.2"
       },
       "engines": {
@@ -15075,9 +15075,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -27574,9 +27574,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -1020,7 +1020,7 @@
     "sinon-chai": "^3.7.0",
     "standard-version": "^9.3.1",
     "tmp": "^0.2.1",
-    "typescript": "^4.3.5",
+    "typescript": "^4.4.2",
     "vscode-extension-tester": "^4.1.2"
   },
   "dependencies": {

--- a/src/commands/createKeystore.ts
+++ b/src/commands/createKeystore.ts
@@ -10,7 +10,7 @@ import { getValidWorkspaceFolders, quickPick } from '../quickpicks';
 import { BUTTONS, SEVERITY } from '@redhat-developer/vscode-wizard/lib/WebviewWizard';
 import { KeystoreInfo } from '../types/common';
 import { CommandBuilder } from '../tasks/commandBuilder';
-import { CommandError } from 'src/common/utils';
+import { CommandError } from '../common/utils';
 
 export async function createKeystore (): Promise<KeystoreInfo> {
 

--- a/src/debugger/titaniumDebugConfigurationProvider.ts
+++ b/src/debugger/titaniumDebugConfigurationProvider.ts
@@ -77,11 +77,10 @@ export class TitaniumDebugConfigurationProvider implements vscode.DebugConfigura
 			try {
 				ourConfig.platform = (await selectPlatform()).id;
 			} catch (error) {
-				let message = error.message;
 				if (error instanceof UserCancellation) {
-					message = 'Failed to start debug session as no platform was selected';
+					throw new Error('Failed to start debug session as no platform was selected');
 				}
-				throw new Error(message);
+				throw error;
 			}
 		}
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -132,6 +132,9 @@ export class Project {
 				this.tiapp = json['ti:app'];
 			}
 		} catch (err) {
+			if (!(err instanceof Error)) {
+				throw err;
+			}
 			let line: number;
 			let column: number;
 			let message = 'Errors found in tiapp.xml';

--- a/src/providers/completion/alloyAutoCompleteRules.ts
+++ b/src/providers/completion/alloyAutoCompleteRules.ts
@@ -15,6 +15,13 @@ interface AlloyAutoCompleteRule {
 	rangeRegex?: RegExp;
 }
 
+interface ImageAutoComplete {
+	prefix: string;
+	suffix: string;
+	file: string;
+	scales: string[]
+}
+
 export const cfgAutoComplete: AlloyAutoCompleteRule = {
 	regExp: /Alloy\.CFG\.([-a-zA-Z0-9-_/]*)[,]?$/,
 	async getCompletions (projectDir) {
@@ -95,7 +102,7 @@ export const imageAutoComplete: AlloyAutoCompleteRule = {
 				nodir: true,
 				filter: item => path.basename(item.path) !== '.DS_Store'
 			});
-			const images = [];
+			const images: ImageAutoComplete[] = [];
 			for (const file of files) {
 				let prefix: string|undefined;
 				let scale: string|undefined;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,7 +5,8 @@ import * as vscode from 'vscode';
 
 import { Commands, handleInteractionError, InteractionChoice, InteractionError, registerCommand } from '../commands';
 import { Project } from '../project';
-import { completion, updates } from 'titanium-editor-commons';
+import { completion, updates  } from 'titanium-editor-commons';
+import { CustomError } from 'titanium-editor-commons/completions/util';
 
 // Import the various providers
 import { CompletionsFormat } from './completion/baseCompletionItemProvider';
@@ -155,7 +156,7 @@ export async function generateCompletions (force = false, project: Project): Pro
 		}
 	} catch (error) {
 		const actions: InteractionChoice[] = [];
-		if (error.code === 'ESDKNOTINSTALLED') {
+		if (error instanceof CustomError && error.code === 'ESDKNOTINSTALLED') {
 			actions.push({
 				title: 'Install',
 				run: () => {
@@ -171,7 +172,8 @@ export async function generateCompletions (force = false, project: Project): Pro
 				}
 			});
 		}
-		const install = await vscode.window.showErrorMessage(`Error generating autocomplete suggestions. ${error.message}`, ...actions);
+		const message = error instanceof Error ? error.message : '';
+		const install = await vscode.window.showErrorMessage(`Error generating autocomplete suggestions. ${message}`, ...actions);
 		if (install) {
 			await install.run();
 		}

--- a/src/tasks/commandTaskProvider.ts
+++ b/src/tasks/commandTaskProvider.ts
@@ -77,7 +77,7 @@ export abstract class CommandTaskProvider implements vscode.TaskProvider {
 			} else if (error instanceof UserCancellation) {
 				context.terminal.writeWarningLine('Task cancelled as no selection occurred');
 				return 0;
-			} else {
+			} else if (error instanceof Error) {
 				message = `${message}\n${error.message}`;
 			}
 

--- a/src/test/integration/util/common.ts
+++ b/src/test/integration/util/common.ts
@@ -232,7 +232,7 @@ export class CommonUICreator {
 				}
 			} catch (error) {
 				// ignore error while we're waiting for the section to load
-				if (error.message?.includes('It looks')) {
+				if (error instanceof Error && error.message?.includes('It looks')) {
 					throw error;
 				}
 			}

--- a/src/updates/index.ts
+++ b/src/updates/index.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { ProductNames, UpdateInfo } from 'titanium-editor-commons/updates';
+import { InstallError } from 'titanium-editor-commons/util';
 import { executeAsTask } from '../utils';
 import { selectUpdates } from '../quickpicks/common';
 import { ExtensionContainer } from '../container';
@@ -49,7 +50,7 @@ export async function installUpdates (updateInfo?: UpdateInfo[], promptForChoice
 					message: `Failed to install ${label} (${counter}/${selectedUpdates})`,
 					increment: 100 / selectedUpdates
 				});
-				if (error.metadata) {
+				if (error instanceof InstallError && error.metadata) {
 					const { metadata } = error;
 					if ((update.productName === ProductNames.AppcInstaller || update.productName === ProductNames.Node) && metadata.errorCode === 'EACCES') {
 						const runWithSudo = await vscode.window.showErrorMessage(`Failed to update to ${label} as it must be ran with sudo`, {


### PR DESCRIPTION
Updates TS to 4.4 and fixes the new errors, mostly the change in strict mode to alway treat `error` in catch clauses being `unknown` instead of `any`.

Will print a warning on `npm run lint` but it still functions