### PR TITLE
feat(providers/definition): support ES6 import file lookups

### DIFF
--- a/src/providers/definition/controllerDefinitionProvider.ts
+++ b/src/providers/definition/controllerDefinitionProvider.ts
@@ -14,8 +14,8 @@ export class ControllerDefinitionProvider extends BaseDefinitionProvider {
 		},
 		{ // ES6 import from (/lib) name
                 	regExp: /import (?:[-a-zA-Z0-9-_/\s]*)['"]([-a-zA-Z0-9-_/]*)$/,
-	                files(project, document, text, value) {
-	                    return [path.join(project.filePath, 'app', 'lib', `${value}.js`)];
+	                files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {
+	                    	return [path.join(project.filePath, 'app', 'lib', `${value}.js`)];
         	        }
             	},
 		{ // controller name

--- a/src/providers/definition/controllerDefinitionProvider.ts
+++ b/src/providers/definition/controllerDefinitionProvider.ts
@@ -13,9 +13,9 @@ export class ControllerDefinitionProvider extends BaseDefinitionProvider {
 			}
 		},
 		{ // ES6 import from (/lib) name
-			regExp: /import (?:[-a-zA-Z0-9-_/\[\]\*\,\s]*)['"]([-a-zA-Z0-9-_/]*)$/,
+			regExp: /import\s*\(?(?:[{-\w-_/[\]*,\s}]*)?['"]?([-\w-_/]*)\)?/,
 			files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {
-				return [path.join(project.filePath, 'app', 'lib', `${value}.js`)];
+				return [ path.join(project.filePath, 'app', 'lib', `${value}.js`) ];
 			}
 		},
 		{ // controller name

--- a/src/providers/definition/controllerDefinitionProvider.ts
+++ b/src/providers/definition/controllerDefinitionProvider.ts
@@ -13,11 +13,11 @@ export class ControllerDefinitionProvider extends BaseDefinitionProvider {
 			}
 		},
 		{ // ES6 import from (/lib) name
-                	regExp: /import (?:[-a-zA-Z0-9-_/\s]*)['"]([-a-zA-Z0-9-_/]*)$/,
-	                files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {
-	                    	return [path.join(project.filePath, 'app', 'lib', `${value}.js`)];
-        	        }
-            	},
+			regExp: /import (?:[-a-zA-Z0-9-_/\s]*)['"]([-a-zA-Z0-9-_/]*)$/,
+			files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {
+				return [path.join(project.filePath, 'app', 'lib', `${value}.js`)];
+			}
+		},
 		{ // controller name
 			regExp: /Alloy\.createController\(["']([-a-zA-Z0-9-_/]*)$/,
 			files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {

--- a/src/providers/definition/controllerDefinitionProvider.ts
+++ b/src/providers/definition/controllerDefinitionProvider.ts
@@ -12,6 +12,12 @@ export class ControllerDefinitionProvider extends BaseDefinitionProvider {
 				return [ path.join(project.filePath, 'app', 'lib', `${value}.js`) ];
 			}
 		},
+		{ // ES6 import from (/lib) name
+                	regExp: /import (?:[-a-zA-Z0-9-_/\s]*)['"]([-a-zA-Z0-9-_/]*)$/,
+	                files(project, document, text, value) {
+	                    return [path.join(project.filePath, 'app', 'lib', `${value}.js`)];
+        	        }
+            	},
 		{ // controller name
 			regExp: /Alloy\.createController\(["']([-a-zA-Z0-9-_/]*)$/,
 			files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {

--- a/src/providers/definition/controllerDefinitionProvider.ts
+++ b/src/providers/definition/controllerDefinitionProvider.ts
@@ -13,7 +13,7 @@ export class ControllerDefinitionProvider extends BaseDefinitionProvider {
 			}
 		},
 		{ // ES6 import from (/lib) name
-			regExp: /import (?:[-a-zA-Z0-9-_/\s]*)['"]([-a-zA-Z0-9-_/]*)$/,
+			regExp: /import (?:[-a-zA-Z0-9-_/\[\]\*\,\s]*)['"]([-a-zA-Z0-9-_/]*)$/,
 			files (project: Project, document: vscode.TextDocument, text: string, value: string): string[] {
 				return [path.join(project.filePath, 'app', 'lib', `${value}.js`)];
 			}

--- a/src/test/common/fixtures/alloy-project/app/controllers/sample.js
+++ b/src/test/common/fixtures/alloy-project/app/controllers/sample.js
@@ -22,3 +22,10 @@ function doClick() {
 
 }
 const btnClick = () => {}
+import http from '/http';
+import '/http';
+import * as foo from '/http';
+import { http } from '/http';
+const http = await import('/http');
+import('/http').then();
+await import('/http');

--- a/src/test/unit/suite/providers/definition/controller.test.ts
+++ b/src/test/unit/suite/providers/definition/controller.test.ts
@@ -96,4 +96,48 @@ describe('Controller definition', () => {
 		expect(suggestions.length).to.equal(1);
 		expect(suggestions[0].targetUri).to.deep.equal(vscode.Uri.file(path.join(getCommonAlloyProjectDirectory(), 'app', 'widgets', 'widget-test', 'models', 'test.js')));
 	});
+
+	it('should support import syntax', async () => {
+		const defaultPosition = new vscode.Position(24, 18);
+		const defaultSuggestions: vscode.LocationLink[] = await testCompletion(defaultPosition) as vscode.LocationLink[];
+
+		expect(defaultSuggestions.length).to.equal(1);
+		expect(defaultSuggestions[0].targetUri).to.deep.equal(vscode.Uri.file(path.join(getCommonAlloyProjectDirectory(), 'app', 'lib', 'http.js')));
+
+		const sideEffectsPosition = new vscode.Position(25, 8);
+		const sideEffectsSuggestions: vscode.LocationLink[] = await testCompletion(sideEffectsPosition) as vscode.LocationLink[];
+
+		expect(sideEffectsSuggestions.length).to.equal(1);
+		expect(sideEffectsSuggestions[0].targetUri).to.deep.equal(vscode.Uri.file(path.join(getCommonAlloyProjectDirectory(), 'app', 'lib', 'http.js')));
+
+		const asPosition = new vscode.Position(26, 22);
+		const asSuggestions: vscode.LocationLink[] = await testCompletion(asPosition) as vscode.LocationLink[];
+
+		expect(asSuggestions.length).to.equal(1);
+		expect(asSuggestions[0].targetUri).to.deep.equal(vscode.Uri.file(path.join(getCommonAlloyProjectDirectory(), 'app', 'lib', 'http.js')));
+
+		const singlePosition = new vscode.Position(27, 22);
+		const singleSuggestions: vscode.LocationLink[] = await testCompletion(singlePosition) as vscode.LocationLink[];
+
+		expect(singleSuggestions.length).to.equal(1);
+		expect(singleSuggestions[0].targetUri).to.deep.equal(vscode.Uri.file(path.join(getCommonAlloyProjectDirectory(), 'app', 'lib', 'http.js')));
+
+		const dynamicAwaitPosition = new vscode.Position(28, 27);
+		const dynamicAwaitSuggestions: vscode.LocationLink[] = await testCompletion(dynamicAwaitPosition) as vscode.LocationLink[];
+
+		expect(dynamicAwaitSuggestions.length).to.equal(1);
+		expect(dynamicAwaitSuggestions[0].targetUri).to.deep.equal(vscode.Uri.file(path.join(getCommonAlloyProjectDirectory(), 'app', 'lib', 'http.js')));
+
+		const dynamicThenPosition = new vscode.Position(29, 8);
+		const dynamicThenSuggestions: vscode.LocationLink[] = await testCompletion(dynamicThenPosition) as vscode.LocationLink[];
+
+		expect(dynamicThenSuggestions.length).to.equal(1);
+		expect(dynamicThenSuggestions[0].targetUri).to.deep.equal(vscode.Uri.file(path.join(getCommonAlloyProjectDirectory(), 'app', 'lib', 'http.js')));
+
+		const dynamicSideEffectsPosition = new vscode.Position(30, 14);
+		const dynamicSideEffectsSuggestions: vscode.LocationLink[] = await testCompletion(dynamicSideEffectsPosition) as vscode.LocationLink[];
+
+		expect(dynamicSideEffectsSuggestions.length).to.equal(1);
+		expect(dynamicSideEffectsSuggestions[0].targetUri).to.deep.equal(vscode.Uri.file(path.join(getCommonAlloyProjectDirectory(), 'app', 'lib', 'http.js')));
+	});
 });


### PR DESCRIPTION
Along with ES5 `require` this should add support to CMD+Click:

```
import navigator from "core/navigator";

import "core/navigator";
```

to open the related file.