### PR TITLE
Add custom tag support, improve attribute detection

### DIFF
--- a/src/providers/completion/alloyAutoCompleteRules.ts
+++ b/src/providers/completion/alloyAutoCompleteRules.ts
@@ -5,7 +5,7 @@ import * as utils from '../../utils';
 import { CompletionItem, CompletionItemKind, workspace, Range } from 'vscode';
 import { ExtensionContainer } from '../../container';
 import { parseXmlString } from '../../common/utils';
-import { Project } from '../..//project';
+import { Project } from '../../project';
 import { pathExists } from 'fs-extra';
 
 interface AlloyAutoCompleteRule {

--- a/src/providers/completion/viewCompletionItemProvider.ts
+++ b/src/providers/completion/viewCompletionItemProvider.ts
@@ -361,9 +361,10 @@ export class ViewCompletionItemProvider extends BaseCompletionItemProvider {
 			quoteIndex--;
 		}
 		linePrefix = linePrefix.substring(0, quoteIndex);
-		const matches = /\s+([a-zA-Z][-a-zA-Z]*)\s*=\s*/.exec(linePrefix);
-		if (matches && matches.length >= 2) {
-			return matches[1];
+		const matches = [ ...linePrefix.matchAll(/\s+([a-zA-Z]*)\s*=\s*/g) ];
+		if (matches.length) {
+			const last = matches.length - 1;
+			return matches[last][1];
 		}
 	}
 }

--- a/src/providers/completion/viewCompletionItemProvider.ts
+++ b/src/providers/completion/viewCompletionItemProvider.ts
@@ -40,7 +40,7 @@ export class ViewCompletionItemProvider extends BaseCompletionItemProvider {
 		} else if (/^\s*<\w+[\s+\w*="()']*\s+\w*[/]?[>]?$/.test(linePrefix)) {
 			return this.getAttributeNameCompletions(linePrefix, position, project, prefix);
 			// attribute value <View backgroundColor="_"
-		} else if (/^\s*<\w+\s+[\s+\w*="()']*\w*="[\w('.]*"[/]?[>]$/.test(linePrefix)) {
+		} else if (/^\s*<\w+\s+([\s+\w*="()']*\w*="[\w('./]*"?)*[/]?[>]?$/.test(linePrefix)) {
 			// first attempt Alloy rules (i18n, image etc.)
 			let ruleResult;
 			for (const rule of Object.values(alloyAutoCompleteRules)) {
@@ -269,6 +269,22 @@ export class ViewCompletionItemProvider extends BaseCompletionItemProvider {
 					});
 				}
 				return completions;
+			}
+		} else if (attribute === 'module') {
+			const libDirectory = path.join(project.filePath, 'app', 'lib');
+			const files = utils.filterJSFiles(libDirectory);
+			const createFunction = `create${tag}`;
+
+			for (const file of files) {
+				const document = await workspace.openTextDocument(file.path);
+				if (document.getText().includes(createFunction)) {
+					const value = utils.toUnixPath(file.path.replace(libDirectory, '').split('.')[0]);
+					completions.push({
+						label: value,
+						kind: CompletionItemKind.Reference,
+						detail: document.fileName
+					});
+				}
 			}
 		}
 

--- a/src/providers/definition/baseDefinitionProvider.ts
+++ b/src/providers/definition/baseDefinitionProvider.ts
@@ -47,7 +47,7 @@ export class BaseDefinitionProvider extends BaseProvider implements vscode.Defin
 						return new vscode.Location(vscode.Uri.file(file), range);
 					});
 				} else {
-					const files = await suggestion.files(project, document, word, value);
+					const files = await suggestion.files(project, document, value || word, value || word);
 					for (const file of files) {
 						const link: vscode.DefinitionLink = {
 							originSelectionRange: new vscode.Range(position.line, startIndex, position.line, endIndex),

--- a/src/providers/definition/common.ts
+++ b/src/providers/definition/common.ts
@@ -109,7 +109,6 @@ export const viewSuggestions: DefinitionSuggestion[] = [
 	{ // widget
 		regExp: /<Widget[\s0-9a-zA-Z-_^='"]*src=["']/,
 		files (project: Project, document: TextDocument, text: string): string[] {
-
 			return [ path.join(project.filePath, 'app', 'widgets', text, 'controllers', 'widget.js') ];
 		}
 	},
@@ -140,5 +139,11 @@ export const viewSuggestions: DefinitionSuggestion[] = [
 			return [ path.join(i18nPath, defaultLang, 'strings.xml') ];
 		},
 		i18nString: true
+	},
+	{ // custom tags
+		regExp: /<\w+[\s0-9a-zA-Z-_^='"]*module=["']/,
+		files (project: Project, document: TextDocument, text: string): string[] {
+			return [ path.join(project.filePath, 'app', 'lib', `${text}.js`) ];
+		}
 	}
 ];

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -29,7 +29,7 @@ export function registerProviders(context: vscode.ExtensionContext): void {
 
 	// register completion providers
 	context.subscriptions.push(
-		vscode.languages.registerCompletionItemProvider({ scheme: 'file', pattern: viewFilePattern }, new ViewCompletionItemProvider(), '.', '\'', '"'),
+		vscode.languages.registerCompletionItemProvider({ scheme: 'file', pattern: viewFilePattern }, new ViewCompletionItemProvider(), '.', '\'', '"', '/'),
 		vscode.languages.registerCompletionItemProvider({ scheme: 'file', pattern: styleFilePattern }, new StyleCompletionItemProvider(), '.', '\'', '"'),
 		vscode.languages.registerCompletionItemProvider({ scheme: 'file', pattern: controllerFilePattern }, new ControllerCompletionItemProvider(), '.', '\'', '"', '/'),
 		vscode.languages.registerCompletionItemProvider({ scheme: 'file', pattern: '**/tiapp.xml' }, new TiappCompletionItemProvider(), '.')

--- a/src/test/common/fixtures/alloy-project/app/lib/folder/custom-view.js
+++ b/src/test/common/fixtures/alloy-project/app/lib/folder/custom-view.js
@@ -1,0 +1,3 @@
+exports.createCustomView = function () {
+
+}

--- a/src/test/common/fixtures/alloy-project/app/views/sample.xml
+++ b/src/test/common/fixtures/alloy-project/app/views/sample.xml
@@ -18,6 +18,7 @@
 		<View id="noexistid" class="noexistclass" onClick="noExistFunc" text="L('noexist')"/>
 		<Button onClick="btnClick" />
 		<Button class="testClass secondClass thirdClass" />
-
+		<CustomView top="30" module="folder/custom-view" />
+		<Require src="folder/test"/>
 	</Tab>
 </Alloy>

--- a/src/test/common/fixtures/alloy-project/app/views/sample.xml
+++ b/src/test/common/fixtures/alloy-project/app/views/sample.xml
@@ -21,5 +21,8 @@
 		<CustomView top="30" module="folder/custom-view" />
 		<Require src="folder/test"/>
 		<CustomView module=""/>
+		<Require text="foo" src="" test="bar"/>
+		<Widget text="foo" src="" test="bar"/>
+		<Label text="foo" color=""/>
 	</Tab>
 </Alloy>

--- a/src/test/common/fixtures/alloy-project/app/views/sample.xml
+++ b/src/test/common/fixtures/alloy-project/app/views/sample.xml
@@ -20,5 +20,6 @@
 		<Button class="testClass secondClass thirdClass" />
 		<CustomView top="30" module="folder/custom-view" />
 		<Require src="folder/test"/>
+		<CustomView module=""/>
 	</Tab>
 </Alloy>

--- a/src/test/unit/suite/providers/completion/controller.test.ts
+++ b/src/test/unit/suite/providers/completion/controller.test.ts
@@ -255,9 +255,9 @@ describe('Controller suggestions', () => {
 			const position = new vscode.Position(9, 9);
 			const suggestions: vscode.CompletionItem[] = await testCompletion(position);
 
-			expect(suggestions.length).to.equal(1);
+			expect(suggestions.length).to.equal(2);
 
-			expect(suggestions[0].label).to.equal('/http');
+			expect(suggestions[0].label).to.equal('/folder/custom-view');
 			expect(suggestions[0].kind).to.equal(17);
 		});
 
@@ -265,57 +265,57 @@ describe('Controller suggestions', () => {
 			const defaultPosition = new vscode.Position(31, 18);
 			const defaultSuggestions: vscode.CompletionItem[] = await testCompletion(defaultPosition);
 
-			expect(defaultSuggestions.length).to.equal(1);
+			expect(defaultSuggestions.length).to.equal(2);
 
-			expect(defaultSuggestions[0].label).to.equal('/http');
+			expect(defaultSuggestions[0].label).to.equal('/folder/custom-view');
 			expect(defaultSuggestions[0].kind).to.equal(17);
 
 			const sideEffectsPosition = new vscode.Position(32, 8);
 			const sideEffectsSuggestions: vscode.CompletionItem[] = await testCompletion(sideEffectsPosition);
 
-			expect(sideEffectsSuggestions.length).to.equal(1);
+			expect(sideEffectsSuggestions.length).to.equal(2);
 
-			expect(sideEffectsSuggestions[0].label).to.equal('/http');
+			expect(sideEffectsSuggestions[0].label).to.equal('/folder/custom-view');
 			expect(sideEffectsSuggestions[0].kind).to.equal(17);
 
 			const asPosition = new vscode.Position(33, 22);
 			const asSuggestions: vscode.CompletionItem[] = await testCompletion(asPosition);
 
-			expect(asSuggestions.length).to.equal(1);
+			expect(asSuggestions.length).to.equal(2);
 
-			expect(asSuggestions[0].label).to.equal('/http');
+			expect(asSuggestions[0].label).to.equal('/folder/custom-view');
 			expect(asSuggestions[0].kind).to.equal(17);
 
 			const singlePosition = new vscode.Position(34, 22);
 			const singleSuggestions: vscode.CompletionItem[] = await testCompletion(singlePosition);
 
-			expect(singleSuggestions.length).to.equal(1);
+			expect(singleSuggestions.length).to.equal(2);
 
-			expect(singleSuggestions[0].label).to.equal('/http');
+			expect(singleSuggestions[0].label).to.equal('/folder/custom-view');
 			expect(singleSuggestions[0].kind).to.equal(17);
 
 			const dynamicAwaitPosition = new vscode.Position(35, 27);
 			const dynamicAwaitSuggestions: vscode.CompletionItem[] = await testCompletion(dynamicAwaitPosition);
 
-			expect(dynamicAwaitSuggestions.length).to.equal(1);
+			expect(dynamicAwaitSuggestions.length).to.equal(2);
 
-			expect(dynamicAwaitSuggestions[0].label).to.equal('/http');
+			expect(dynamicAwaitSuggestions[0].label).to.equal('/folder/custom-view');
 			expect(dynamicAwaitSuggestions[0].kind).to.equal(17);
 
 			const dynamicThenPosition = new vscode.Position(36, 8);
 			const dynamicThenSuggestions: vscode.CompletionItem[] = await testCompletion(dynamicThenPosition);
 
-			expect(dynamicThenSuggestions.length).to.equal(1);
+			expect(dynamicThenSuggestions.length).to.equal(2);
 
-			expect(dynamicThenSuggestions[0].label).to.equal('/http');
+			expect(dynamicThenSuggestions[0].label).to.equal('/folder/custom-view');
 			expect(dynamicThenSuggestions[0].kind).to.equal(17);
 
 			const dynamicSideEffectsPosition = new vscode.Position(37, 14);
 			const dynamicSideEffectsSuggestions: vscode.CompletionItem[] = await testCompletion(dynamicSideEffectsPosition);
 
-			expect(dynamicSideEffectsSuggestions.length).to.equal(1);
+			expect(dynamicSideEffectsSuggestions.length).to.equal(2);
 
-			expect(dynamicSideEffectsSuggestions[0].label).to.equal('/http');
+			expect(dynamicSideEffectsSuggestions[0].label).to.equal('/folder/custom-view');
 			expect(dynamicSideEffectsSuggestions[0].kind).to.equal(17);
 
 		});

--- a/src/test/unit/suite/providers/completion/view.test.ts
+++ b/src/test/unit/suite/providers/completion/view.test.ts
@@ -130,4 +130,14 @@ describe('View suggestions', () => {
 		expect(suggestions[0].label).to.equal('widget-test');
 		expect(suggestions[0].kind).to.equal(17);
 	});
+
+	it('should provide custom tag module suggestions', async () => {
+		const position = new vscode.Position(22, 37);
+		const suggestions: vscode.CompletionItem[] = await testCompletion(position);
+
+		expect(suggestions.length).to.equal(1);
+
+		expect(suggestions[0].label).to.equal('/folder/custom-view');
+		expect(suggestions[0].kind).to.equal(17);
+	});
 });

--- a/src/test/unit/suite/providers/completion/view.test.ts
+++ b/src/test/unit/suite/providers/completion/view.test.ts
@@ -86,6 +86,14 @@ describe('View suggestions', () => {
 
 		expect(suggestions[0].label).to.equal('transparent');
 		expect(suggestions[0].kind).to.equal(11);
+
+		const multiPropertyPosition = new vscode.Position(25, 34);
+		const multiPropertySuggestions: vscode.CompletionItem[] = await testCompletion(multiPropertyPosition);
+
+		expect(multiPropertySuggestions.length).to.equal(24);
+
+		expect(multiPropertySuggestions[0].label).to.equal('transparent');
+		expect(multiPropertySuggestions[0].kind).to.equal(11);
 	});
 
 	it('should provide tss class suggestions', async () => {
@@ -119,6 +127,14 @@ describe('View suggestions', () => {
 
 		expect(suggestions[0].label).to.equal('/existing-file');
 		expect(suggestions[0].kind).to.equal(17);
+
+		const multiPropertyPosition = new vscode.Position(23, 27);
+		const multiPropertySuggestions: vscode.CompletionItem[] = await testCompletion(multiPropertyPosition);
+
+		expect(multiPropertySuggestions.length).to.equal(4);
+
+		expect(multiPropertySuggestions[0].label).to.equal('/existing-file');
+		expect(multiPropertySuggestions[0].kind).to.equal(17);
 	});
 
 	it('should provide widget src suggestions', async () => {
@@ -129,6 +145,14 @@ describe('View suggestions', () => {
 
 		expect(suggestions[0].label).to.equal('widget-test');
 		expect(suggestions[0].kind).to.equal(17);
+
+		const multiPropertyPosition = new vscode.Position(24, 26);
+		const multiPropertySuggestions: vscode.CompletionItem[] = await testCompletion(multiPropertyPosition);
+
+		expect(multiPropertySuggestions.length).to.equal(1);
+
+		expect(multiPropertySuggestions[0].label).to.equal('widget-test');
+		expect(multiPropertySuggestions[0].kind).to.equal(17);
 	});
 
 	it('should provide custom tag module suggestions', async () => {

--- a/src/test/unit/suite/providers/definition/view.test.ts
+++ b/src/test/unit/suite/providers/definition/view.test.ts
@@ -96,6 +96,12 @@ describe('View definition', () => {
 
 		expect(suggestions.length).to.equal(1);
 		expect(suggestions[0].targetUri).to.deep.equal(vscode.Uri.file(path.join(getCommonAlloyProjectDirectory(), 'app', 'controllers', 'existing-file.js')));
+
+		const subFolderPosition = new vscode.Position(21, 22);
+		const subFolderSuggestions: vscode.DefinitionLink[] = await testCompletion(subFolderPosition) as vscode.DefinitionLink[];
+
+		expect(subFolderSuggestions.length).to.equal(1);
+		expect(subFolderSuggestions[0].targetUri).to.deep.equal(vscode.Uri.file(path.join(getCommonAlloyProjectDirectory(), 'app', 'controllers', 'folder', 'test.js')));
 	});
 
 	it('should provide i18n definitions', async () => {
@@ -104,5 +110,13 @@ describe('View definition', () => {
 
 		expect(suggestions.length).to.equal(1);
 		expect(suggestions[0].uri.fsPath).to.equal(path.join(getCommonAlloyProjectDirectory(), 'app', 'i18n', 'en', 'strings.xml'));
+	});
+
+	it('should provide module definitions for custom tags', async () => {
+		const position = new vscode.Position(20, 37);
+		const suggestions: vscode.DefinitionLink[] = await testCompletion(position) as vscode.DefinitionLink[];
+
+		expect(suggestions.length).to.equal(1);
+		expect(suggestions[0].targetUri).to.deep.equal(vscode.Uri.file(path.join(getCommonAlloyProjectDirectory(), 'app', 'lib', 'folder', 'custom-view.js')));
 	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "target": "es6",
         "outDir": "out",
         "lib": [
-            "es2018"
+            "es2020"
         ],
         "moduleResolution": "node",
         "sourceMap": true,


### PR DESCRIPTION
This PR adds support for providing definition links for custom tags on the `module` attribute and also for completions for that attribute.

It also fixes the parsing of attributes when multiple are present in a single tag