### PR TITLE
fix: reduce activation events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-titanium",
-  "version": "0.12.4",
+  "version": "0.12.5-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-titanium",
-  "version": "0.12.5-1",
+  "version": "0.12.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-titanium",
-  "version": "0.12.5-1",
+  "version": "0.12.4",
   "displayName": "Titanium",
   "description": "Intellisense, snippets, and integrated build tools for Titanium",
   "icon": "images/logo-titanium.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-titanium",
-  "version": "0.12.4",
+  "version": "0.12.5-1",
   "displayName": "Titanium",
   "description": "Intellisense, snippets, and integrated build tools for Titanium",
   "icon": "images/logo-titanium.png",
@@ -35,12 +35,7 @@
     "node": ">=14.16.0"
   },
   "activationEvents": [
-    "*",
-    "onDebug",
-    "onCommand:titanium.create.application",
-    "onCommand:titanium.create.module",
-    "workspaceContains:tiapp.xml",
-    "workspaceContains:**/timodule.xml"
+    "*"
   ],
   "capabilities": {
     "untrustedWorkspaces": {


### PR DESCRIPTION
This was seemingly causing an issues in some instances. We don't actually need everything else given that `*` means always so lets just remove them

Fixes #887