### PR TITLE
fix: update dependency to fix keystore creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "Apache 2.0",
       "dependencies": {
         "@awam/remotedebug-ios-webkit-adapter": "^0.4.3",
-        "@redhat-developer/vscode-wizard": "^0.2.19",
         "detect-indent": "^6.1.0",
         "find-up": "^5.0.0",
         "fs-extra": "^10.0.0",
@@ -26,6 +25,7 @@
         "uuid": "^8.3.2",
         "vscode-chrome-debug-core": "^6.8.11",
         "vscode-debugadapter": "^1.50.0",
+        "vscode-wizard": "^0.2.20",
         "which": "^2.0.2",
         "xml2js": "^0.4.23"
       },
@@ -1569,14 +1569,6 @@
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^7.3.3"
-      }
-    },
-    "node_modules/@redhat-developer/vscode-wizard": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@redhat-developer/vscode-wizard/-/vscode-wizard-0.2.19.tgz",
-      "integrity": "sha512-hi/Q1OePXKhfgcXZRVor2gg5IyjDW0VjXmiz23l0PpB8tBYPadjtNsrRIw2RiXm4YW4AOdviqa3iR1IcVWwjiQ==",
-      "dependencies": {
-        "handlebars": "^4.7.3"
       }
     },
     "node_modules/@seadub/danger-plugin-dependencies": {
@@ -13479,6 +13471,17 @@
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.1.tgz",
       "integrity": "sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A=="
     },
+    "node_modules/vscode-wizard": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/vscode-wizard/-/vscode-wizard-0.2.20.tgz",
+      "integrity": "sha512-yUbkYcJNUDGvxUKYwOGVLY8ZMaLwhbJFFxycQMn19jXpDQhqweErKTtPkTwZ8VEMFglkClzkO9vJ1Ny3QH/rzQ==",
+      "dependencies": {
+        "handlebars": "^4.7.3"
+      },
+      "engines": {
+        "vscode": "^1.54.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -15102,14 +15105,6 @@
       "dev": true,
       "requires": {
         "@octokit/openapi-types": "^7.3.3"
-      }
-    },
-    "@redhat-developer/vscode-wizard": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@redhat-developer/vscode-wizard/-/vscode-wizard-0.2.19.tgz",
-      "integrity": "sha512-hi/Q1OePXKhfgcXZRVor2gg5IyjDW0VjXmiz23l0PpB8tBYPadjtNsrRIw2RiXm4YW4AOdviqa3iR1IcVWwjiQ==",
-      "requires": {
-        "handlebars": "^4.7.3"
       }
     },
     "@seadub/danger-plugin-dependencies": {
@@ -24290,6 +24285,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.1.tgz",
       "integrity": "sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A=="
+    },
+    "vscode-wizard": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/vscode-wizard/-/vscode-wizard-0.2.20.tgz",
+      "integrity": "sha512-yUbkYcJNUDGvxUKYwOGVLY8ZMaLwhbJFFxycQMn19jXpDQhqweErKTtPkTwZ8VEMFglkClzkO9vJ1Ny3QH/rzQ==",
+      "requires": {
+        "handlebars": "^4.7.3"
+      }
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -1035,7 +1035,7 @@
   },
   "dependencies": {
     "@awam/remotedebug-ios-webkit-adapter": "^0.4.3",
-    "@redhat-developer/vscode-wizard": "^0.2.19",
+    "vscode-wizard": "^0.2.20",
     "detect-indent": "^6.1.0",
     "find-up": "^5.0.0",
     "fs-extra": "^10.0.0",

--- a/src/commands/createKeystore.ts
+++ b/src/commands/createKeystore.ts
@@ -4,10 +4,8 @@ import * as vscode from 'vscode';
 
 import Appc from '../appc';
 import { ExtensionContainer } from '../container';
-import { ValidatorResponse, WebviewWizard, WizardDefinition, WizardPageSectionDefinition } from '@redhat-developer/vscode-wizard';
-import { PerformFinishResponse } from '@redhat-developer/vscode-wizard/lib/IWizardWorkflowManager';
+import { ValidatorResponse, WebviewWizard, WizardDefinition, WizardPageSectionDefinition, BUTTONS, SEVERITY, PerformFinishResponse } from 'vscode-wizard';
 import { getValidWorkspaceFolders, quickPick } from '../quickpicks';
-import { BUTTONS, SEVERITY } from '@redhat-developer/vscode-wizard/lib/WebviewWizard';
 import { KeystoreInfo } from '../types/common';
 import { CommandBuilder } from '../tasks/commandBuilder';
 import { CommandError } from '../common/utils';


### PR DESCRIPTION
It seems VS Code broke how the dependency loaded the webview assets