### PR TITLE
refactor(ios): dropped obsolete `getCorrectCertificateName()`

### DIFF
--- a/src/tasks/helpers/ios.ts
+++ b/src/tasks/helpers/ios.ts
@@ -1,6 +1,5 @@
 import { TaskExecutionContext } from '../tasksHelper';
 import { selectiOSCertificate, selectiOSProvisioningProfile } from '../../quickpicks/build/ios';
-import { getCorrectCertificateName } from '../../utils';
 import { IosCert } from '../../types/common';
 import { TaskHelper } from './base';
 import { Command } from '../commandBuilder';
@@ -51,14 +50,14 @@ export class IosHelper extends TaskHelper {
 			if (!iosInfo.certificate) {
 				certificate = await selectiOSCertificate('run');
 			} else {
-				certificate = ExtensionContainer.environment.iOSCertificates().find(cert => cert.fullname === iosInfo.certificate);
+				certificate = ExtensionContainer.environment.iOSCertificates('developer').find(cert => cert.fullname === iosInfo.certificate);
 			}
 
 			if (!certificate) {
 				throw new Error(`Unable to find certificate ${iosInfo.certificate}`);
 			}
 
-			iosInfo.certificate =  getCorrectCertificateName(certificate.fullname, project.sdk()[0], 'developer');
+			iosInfo.certificate = certificate.fullname;
 
 			if (!iosInfo.provisioningProfile) {
 				iosInfo.provisioningProfile = (await selectiOSProvisioningProfile(certificate, definition.target, project.appId())).uuid;
@@ -100,7 +99,7 @@ export class IosHelper extends TaskHelper {
 			throw new Error(`Unable to find certificate ${iosInfo.certificate}`);
 		}
 
-		iosInfo.certificate =  getCorrectCertificateName(certificate.fullname, project.sdk()[0], 'distribution');
+		iosInfo.certificate = certificate.fullname;
 
 		if (!iosInfo.provisioningProfile) {
 			iosInfo.provisioningProfile = (await selectiOSProvisioningProfile(certificate, definition.target, project.appId())).uuid;

--- a/src/test/unit/suite/utils.test.ts
+++ b/src/test/unit/suite/utils.test.ts
@@ -52,22 +52,6 @@ describe('utils', () => {
 		});
 	});
 
-	it('getCorrectCertificateName Should return correct name property for <8.2.0', () => {
-		const certificate = utils.getCorrectCertificateName('iPhone Developer: Mrs Developer (D4BDS41234)', '8.1.1.GA', 'developer');
-		expect(certificate).to.equal('Mrs Developer (D4BDS41234)');
-	});
-
-	it('getCorrectCertificateName return correct name property for >=8.2.0', () => {
-		const certificate = utils.getCorrectCertificateName('iPhone Developer: Mrs Developer (D4BDS41234)', '8.2.0.GA', 'developer');
-		expect(certificate).to.equal('iPhone Developer: Mrs Developer (D4BDS41234)');
-	});
-
-	it('getCorrectCertificateName should throw if cant find certificate', () => {
-		expect(() => {
-			utils.getCorrectCertificateName('iPhone Developer: Mrs Developer (D4BDS41233)', '8.2.0.GA', 'developer');
-		}).to.throw('Failed to lookup certificate iPhone Developer: Mrs Developer (D4BDS41233)');
-	});
-
 	it('findProjectDirectory', async () => {
 		const file = path.join(getCommonAlloyProjectDirectory(), 'app', 'controllers', 'sample.js');
 		const dir = await utils.findProjectDirectory(file);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -304,36 +304,6 @@ export function matches (text: string, test: string): boolean {
 	return new RegExp(test, 'i').test(text);
 }
 
-/**
- * Determine the correct certificate name value to provide to the SDK build process.
- * Prior to SDK 8.2.0 only the "name" property was allowed, but for 8.2.0 and above
- * we should prefer the fullname as it differentiates between the iPhone certs and
- * the generic Apple certs.
- *
- * @param {String} certificateName - Certificate fullname.
- * @param {String} sdkVersion - Projects SDK version in the tiapp.xml.
- * @param {String} certificateType - Type of certificate type to look up, developer or distribution.
- *
- * @returns {String}
- */
-export function getCorrectCertificateName (certificateName: string, sdkVersion: string, certificateType: IosCertificateType): string {
-	const certificate = ExtensionContainer.environment.iOSCertificates(certificateType).find((cert: IosCert) => cert.fullname === certificateName);
-
-	if (!certificate) {
-		throw new Error(`Failed to lookup certificate ${certificateName}`);
-	}
-
-	const coerced = semver.coerce(sdkVersion);
-
-	// If we cant coerce the SDK version just assume it's newer than 8.2.0 because lets be honest,
-	// it almost certainly is
-	if (!coerced || semver.gte(coerced, '8.2.0')) {
-		return certificate.fullname;
-	} else {
-		return certificate.name;
-	}
-}
-
 export async function getNodeSupportedVersion(): Promise<string|undefined> {
 	// TODO: we'll just take the first app project for now and use that as the supported range,
 	// this should potentially be improved in future to collate the various supported ranges,


### PR DESCRIPTION
- dropped `getCorrectCertificateName()` from the Ti SDK 8.2.0 era
  - cert names have now always the prefix `iPhone Developer: `, `Apple Development: `, `iPhone: Distribution: ` or `Apple: Distribution: ` &rarr; always use of `fullname`
- removed associated unit tests too
